### PR TITLE
overload-config: ensure config is reloaded

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,15 +59,39 @@ exclude = '''
   | dist
 )/
 '''
-extend-ignore = "E203,E501"
+extend-ignore = "E501"
 
 # Configurations for pytest
 [tool.pytest]
-addopts = ["-ra", "--cov=your_project_name", "--cov-report=term-missing"]
+addopts = ["-ra", "--cov=tesla_smart_charger", "--cov-report=term-missing"]
 testpaths = ["tests"]
 
 [toolpytest.cov]
 fail_under = 80
+
+[tool.ruff]
+ignore = [
+  "T201", # print() used
+  "S104", # bind to all interfaces
+  "S105", # possible hardcoded password
+  "D201", # No blank lines allowed before function docstring
+  "PLR2004", # Use Magic Numbers
+]
+extend-ignore = ["N815"] # mixedCase variable in function scope
+select = ["ALL"]
+target-version = "py310"
+# Same as Black.
+line-length = 88
+
+[tool.ruff.per-file-ignores]
+"tests/**/*.py" = ["S101"] # Use of assert detected.
+
+[tool.ruff.mccabe]
+# Implicit 10 is too low for our codebase, even black uses 18 as default.
+max-complexity = 20
+
+[tool.ruff.flake8-builtins]
+builtins-ignorelist = ["id"]
 
 # Configurations for tox
 [tool.tox]

--- a/tesla_smart_charger/__init__.py
+++ b/tesla_smart_charger/__init__.py
@@ -1,0 +1,1 @@
+"""Init file for tesla_smart_charger."""

--- a/tesla_smart_charger/__main__.py
+++ b/tesla_smart_charger/__main__.py
@@ -101,8 +101,6 @@ def read_root():
 def overload():
     try:
         vehicle_data = tesla_api.get_vehicle_data()
-        if constants.VERBOSE:
-            print(vehicle_data)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Request failed: {str(e)}")
 
@@ -121,8 +119,6 @@ def overload():
         try:
             # Set the new charge limit
             response = tesla_api.set_charge_amp_limit(int(new_charge_limit))
-            if constants.VERBOSE:
-                print("Request successful:", response)
         except Exception as e:
             return {"error": f"Set charge limit failed: {str(e)}"}
 

--- a/tesla_smart_charger/charger_config.py
+++ b/tesla_smart_charger/charger_config.py
@@ -1,6 +1,4 @@
-"""
-Configurator class for Tesla Smart Charger.
-"""
+"""Configurator class for Tesla Smart Charger."""
 
 
 import json
@@ -8,14 +6,14 @@ import pathlib
 
 from pydantic import BaseModel
 
-import tesla_smart_charger.constants as constants
+from tesla_smart_charger import constants
 
 
 class ChargerConfig:
     """Configurator class for Tesla Smart Charger.
 
-    Attributes:
-
+    Attributes
+    ----------
         config_file (pathlib): Path to the configuration file.
         config (dict): The configuration.
 
@@ -25,7 +23,7 @@ class ChargerConfig:
         """Initialize the configurator.
 
         Args:
-
+        ----
             config_file (pathlib): Path to the configuration file.
 
         """
@@ -35,63 +33,70 @@ class ChargerConfig:
     def load_config(self: object) -> dict:
         """Load the configuration file.
 
-        Returns:
-
+        Returns
+        -------
                 dict: The configuration.
 
         """
-
         try:
-            with open(self.config_file, "r") as file:
+            with pathlib.Path.open(pathlib.Path(self.config_file), "r") as file:
                 self.config = json.load(file)
             self.validate_config(self.config)
-            return self.config
         except FileNotFoundError as error:
             return {"error": f"Config file not found: {error}"}
         except json.JSONDecodeError as error:
             return {"error": f"Config file is not valid JSON: {error}"}
         except ValueError as error:
             return {"error": f"Config file is not valid: {error}"}
+        else:
+            return self.config
+
 
     def get_config(self: object) -> dict:
         """Return the configuration.
 
-        Returns:
-
+        Returns
+        -------
             dict: The configuration.
         """
         return self.config
 
     def set_config(self: object, config: BaseModel) -> dict:
         """Set the configuration.
-        
+
         Args:
+        ----
             config (BaseModel): The configuration.
 
         Returns:
+        -------
             dict: The configuration.
 
         """
         try:
             self.validate_config(config)
-            with open(self.config_file, "w") as file:
+            with pathlib.Path.open(pathlib.Path(self.config_file), "w") as file:
                 file.write(config)
             self.load_config()
-            return self.config
         except ValueError as error:
             return {"error": f"Config is not valid: {error}"}
+        else:
+            return self.config
 
     @staticmethod
     def validate_config(config: dict) -> None:
         """Validate the configuration.
 
         Args:
+        ----
             config (dict): The configuration.
 
-            Raises:
+        Raises:
+        ------
                 SystemExit: If the configuration is not valid.
 
         """
         for key in constants.REQUIRED_CONFIG_KEYS:
             if key not in config:
-                raise ValueError(f"Config file is missing required key: {key}")
+                msg = f"Missing required config key: {key}"
+                raise ValueError(msg)

--- a/tesla_smart_charger/constants.py
+++ b/tesla_smart_charger/constants.py
@@ -1,6 +1,4 @@
-"""
-Constants for the Tesla Smart Charger integration.
-"""
+"""Constants for the Tesla Smart Charger integration."""
 
 # Verbose mode
 VERBOSE = False
@@ -57,7 +55,9 @@ TESLA_API_VEHICLES_URL = f"{TESLA_API_BASE_URL}/api/1/vehicles"
 TESLA_API_VEHICLE_DATA_URL = f"{TESLA_API_BASE_URL}/api/1/vehicles/{{id}}/vehicle_data"
 
 # URL for the Tesla API to set the charging Amperage limit
-TESLA_API_CHARGE_AMP_LIMIT_URL = f"{TESLA_API_BASE_URL}/api/1/vehicles/{{id}}/command/set_charging_amps"
+TESLA_API_CHARGE_AMP_LIMIT_URL = (
+    f"{TESLA_API_BASE_URL}/api/1/vehicles/{{id}}/command/set_charging_amps"
+)
 
 # Energy Monitor Controller states
 EM_CONTROLLER_STATE_IDLE = "IDLE"

--- a/tesla_smart_charger/constants.py
+++ b/tesla_smart_charger/constants.py
@@ -5,6 +5,9 @@ Constants for the Tesla Smart Charger integration.
 # Verbose mode
 VERBOSE = False
 
+# Request delay in milliseconds
+REQUEST_DELAY_MS = 3000
+
 # Path to the configuration file
 CONFIG_FILE = "config.json"
 

--- a/tesla_smart_charger/controllers/__init__.py
+++ b/tesla_smart_charger/controllers/__init__.py
@@ -1,0 +1,1 @@
+"""Init file for controllers."""

--- a/tesla_smart_charger/controllers/em_controller.py
+++ b/tesla_smart_charger/controllers/em_controller.py
@@ -1,5 +1,4 @@
-"""
-Energy Monitor Controller
+"""Energy Monitor Controller.
 
 This controller is responsible for monitoring the energy usage of the house
 to determine if the power limit can be increased or decreased.
@@ -13,45 +12,33 @@ from abc import ABC, abstractmethod
 
 
 class EnergyMonitorController(ABC):
-    """
-    Abstract class that defines the interface for the controller
-    """
+    """Abstract class that defines the interface for the controller."""
 
     @abstractmethod
     def get_state(self: object) -> str:
-        """
-        Returns the current state of the controller
-        """
-        pass
+        """Return the current state of the controller."""
 
     @abstractmethod
     def set_state(self: object, state: str) -> None:
-        """
-        Sets the current state of the controller
-        """
-        pass
+        """Set the current state of the controller."""
 
     @abstractmethod
     def get_consumption(self: object) -> float:
-        """
-        Returns the current consumption of the house
-        """
-        pass
+        """Return the current consumption of the house."""
 
 
-"""
-Energy Monitor Controller Factory
-"""
+"""Energy Monitor Controller Factory."""
+
+
 def create_energy_monitor_controller(
-    implementation_type: str, host: str
+    implementation_type: str,
+    host: str,
 ) -> EnergyMonitorController:
-    """
-    Factory function to create instances of EnergyMonitorController based on the
-    implementation_type
-    """
-    import tesla_smart_charger.controllers.shelly_em_controller as shelly_em_controller
+    """Create instances of EnergyMonitorController based on the implementation_type."""
+    from tesla_smart_charger.controllers import shelly_em_controller
 
     if implementation_type == "shelly_em":
         return shelly_em_controller.ShellyEMController(host)
-    else:
-        raise ValueError("Invalid implementation type")
+
+    msg = f"Invalid implementation type: {implementation_type}"
+    raise ValueError(msg)

--- a/tesla_smart_charger/controllers/shelly_em_controller.py
+++ b/tesla_smart_charger/controllers/shelly_em_controller.py
@@ -6,6 +6,8 @@ This controller monitors the power consumption of the Shelly EM device
 
 import requests
 
+from retrying import retry
+
 import tesla_smart_charger.constants as constants
 
 from tesla_smart_charger.controllers.em_controller import EnergyMonitorController
@@ -36,6 +38,11 @@ class ShellyEMController(EnergyMonitorController):
         """
         self.state = state
 
+    @retry(
+        wait_exponential_multiplier=constants.REQUEST_DELAY_MS,
+        wait_exponential_max=10000,
+        stop_max_attempt_number=10,
+    )
     def get_consumption(self: object) -> float:
         """
         Returns the current consumption of the house

--- a/tesla_smart_charger/controllers/shelly_em_controller.py
+++ b/tesla_smart_charger/controllers/shelly_em_controller.py
@@ -1,23 +1,20 @@
-"""
-Shelly EM controller implementation
+"""Shelly EM controller implementation.
 
 This controller monitors the power consumption of the Shelly EM device
 """
 
 import requests
-
 from retrying import retry
 
-import tesla_smart_charger.constants as constants
-
+from tesla_smart_charger import constants
 from tesla_smart_charger.controllers.em_controller import EnergyMonitorController
 
 
 class ShellyEMController(EnergyMonitorController):
+    """Shelly EM controller implementation."""
+
     def __init__(self: object, host: str) -> None:
-        """
-        Initializes the Shelly EM controller
-        """
+        """Initialize the Shelly EM controller."""
         self.type = "shelly_em"
         self.state = constants.EM_CONTROLLER_STATE_IDLE
         self.consumption = 0
@@ -27,15 +24,11 @@ class ShellyEMController(EnergyMonitorController):
         self.url = f"http://{host}/status/"
 
     def get_state(self: object) -> str:
-        """
-        Returns the current state of the controller
-        """
+        """Return the current state of the controller."""
         return self.state
 
     def set_state(self: object, state: str) -> None:
-        """
-        Sets the current state of the controller
-        """
+        """Set the current state of the controller."""
         self.state = state
 
     @retry(
@@ -44,10 +37,8 @@ class ShellyEMController(EnergyMonitorController):
         stop_max_attempt_number=10,
     )
     def get_consumption(self: object) -> float:
-        """
-        Returns the current consumption of the house
-        """
-        response = requests.get(self.url)
+        """Return the current consumption of the house."""
+        response = requests.get(self.url, timeout=10)
         response_json = response.json()
         self.last_consumption = self.consumption
 

--- a/tesla_smart_charger/handlers/__init__.py
+++ b/tesla_smart_charger/handlers/__init__.py
@@ -1,0 +1,1 @@
+"""Init file for handlers."""

--- a/tesla_smart_charger/handlers/overload_handler.py
+++ b/tesla_smart_charger/handlers/overload_handler.py
@@ -12,9 +12,18 @@ from tesla_smart_charger.controllers import em_controller as _em_controller
 from tesla_smart_charger.charger_config import ChargerConfig
 from tesla_smart_charger.tesla_api import TeslaAPI
 
+
 tesla_config = ChargerConfig(constants.CONFIG_FILE)
 tesla_config.load_config()
 tesla_api = TeslaAPI(tesla_config)
+
+
+def _reload_config():
+    """
+    Reloads the config
+    """
+    tesla_config.load_config()
+    tesla_api.charger_config = tesla_config
 
 
 def _calculate_new_charge_limit(
@@ -63,6 +72,7 @@ def handle_overload():
     time.sleep(int(tesla_config.config["sleepTimeSecs"]))
     # Get the current vehicle data
     try:
+        _reload_config()
         vehicle_data = tesla_api.get_vehicle_data()
     except Exception as e:
         print("Supervised session interrupted!")
@@ -72,7 +82,7 @@ def handle_overload():
         vehicle_data["state"] == "online"
         and vehicle_data["charge_state"]["charging_state"] == "Charging"
     ):
-        tesla_config.load_config()
+        _reload_config()
         # Get the current charge limit in amps
         charger_actual_current = vehicle_data["charge_state"]["charger_actual_current"]
 

--- a/tesla_smart_charger/handlers/overload_handler.py
+++ b/tesla_smart_charger/handlers/overload_handler.py
@@ -1,27 +1,21 @@
-"""
-Handles the overload of the charger
-"""
+"""Handles the overload of the charger."""
 
 import time
 
 from fastapi import HTTPException
 
-import tesla_smart_charger.constants as constants
-from tesla_smart_charger.controllers import em_controller as _em_controller
-
+from tesla_smart_charger import constants
 from tesla_smart_charger.charger_config import ChargerConfig
+from tesla_smart_charger.controllers import em_controller as _em_controller
 from tesla_smart_charger.tesla_api import TeslaAPI
-
 
 tesla_config = ChargerConfig(constants.CONFIG_FILE)
 tesla_config.load_config()
 tesla_api = TeslaAPI(tesla_config)
 
 
-def _reload_config():
-    """
-    Reloads the config
-    """
+def _reload_config() -> None:
+    """Reload the config."""
     tesla_config.load_config()
     tesla_api.charger_config = tesla_config
 
@@ -33,11 +27,10 @@ def _calculate_new_charge_limit(
     min_charge_limit: float,
     home_max_amps: float,
 ) -> int:
-    """
-    Calculates the new charge limit based on the current charge limit and the
-    current consumption of the house
-    """
+    """Calculate the new charge limit.
 
+    Based on the current charge limit and the current consumption of the house.
+    """
     consumption_difference = current_em_consumption - home_max_amps
 
     # Adjust the charge limit based on the consumption difference
@@ -51,10 +44,8 @@ def _calculate_new_charge_limit(
     return int(new_charge_limit)
 
 
-def handle_overload():
-    """
-    Handles the overload of the charger
-    """
+def handle_overload() -> None:
+    """Handle the overload of the charger."""
     print("Handling overload!")
     print("Supervised session started!")
     # Instantiate the Energy Monitor controller
@@ -63,10 +54,13 @@ def handle_overload():
             tesla_config.config["energyMonitorType"],
             tesla_config.config["energyMonitorIp"],
         )
-    except ValueError:
+    except ValueError as e:
         print("Invalid energy monitor type")
         print("Supervised session ended!")
-        raise HTTPException(status_code=500, detail="Invalid energy monitor type")
+        raise HTTPException(
+            status_code=500,
+            detail="Invalid energy monitor type",
+        ) from e
 
     # Sleep for the configured time
     time.sleep(int(tesla_config.config["sleepTimeSecs"]))
@@ -74,9 +68,11 @@ def handle_overload():
     try:
         _reload_config()
         vehicle_data = tesla_api.get_vehicle_data()
-    except Exception as e:
+    except HTTPException as e:
         print("Supervised session interrupted!")
-        raise HTTPException(status_code=500, detail=f"Request failed: {str(e)}")
+        raise HTTPException(
+            status_code=e.status_code, detail=f"Request failed: {e!s}",
+        ) from e
 
     while (
         vehicle_data["state"] == "online"
@@ -93,7 +89,9 @@ def handle_overload():
         current_em_consumption_amps = current_em_consumption * 1000 / 230
 
         print(
-            f"Current charge limit: {charger_actual_current}A, current house consumption: {current_em_consumption}kW, current house consumption: {current_em_consumption_amps}A"
+            f"Current charge limit: {charger_actual_current}A, "
+            f"current house consumption: {current_em_consumption}kW, "
+            f"current house consumption: {current_em_consumption_amps}A",
         )
 
         # Calculate the new charge limit
@@ -110,9 +108,12 @@ def handle_overload():
             # Set the new charge limit
             try:
                 tesla_api.set_charge_amp_limit(new_charge_limit)
-            except Exception as e:
+            except HTTPException as e:
                 print("Supervised session interrupted!")
-                raise HTTPException(status_code=500, detail=f"Request failed: {str(e)}")
+                raise HTTPException(
+                    status_code=e.status_code,
+                    detail=f"Request failed: {e!s}",
+                ) from e
         else:
             print("No change in charge limit")
 
@@ -122,8 +123,10 @@ def handle_overload():
         # Get the current vehicle data
         try:
             vehicle_data = tesla_api.get_vehicle_data()
-        except Exception as e:
+        except HTTPException as e:
             print("Supervised session interrupted!")
-            raise HTTPException(status_code=500, detail=f"Request failed: {str(e)}")
+            raise HTTPException(
+                status_code=e.status_code, detail=f"Request failed: {e!s}",
+            ) from e
 
     print("Overload handled!")

--- a/tesla_smart_charger/tesla_api.py
+++ b/tesla_smart_charger/tesla_api.py
@@ -30,7 +30,7 @@ class TeslaAPI:
         """
         self.charger_config = charger_config
 
-    @retry(wait_exponential_multiplier=1000, wait_exponential_max=10000, stop_max_attempt_number=5)
+    @retry(wait_exponential_multiplier=constants.REQUEST_DELAY_MS, wait_exponential_max=10000, stop_max_attempt_number=5)
     def get_vehicles(self: object) -> dict:
         """Get the vehicles from the Tesla API.
 
@@ -58,7 +58,7 @@ class TeslaAPI:
         return response["response"]
 
 
-    @retry(wait_exponential_multiplier=1000, wait_exponential_max=10000, stop_max_attempt_number=5)
+    @retry(wait_exponential_multiplier=constants.REQUEST_DELAY_MS, wait_exponential_max=10000, stop_max_attempt_number=5)
     def get_vehicle_data(self: object) -> dict:
         """Get the vehicle data from the Tesla API.
 
@@ -86,7 +86,7 @@ class TeslaAPI:
 
         return response["response"]
 
-    @retry(wait_exponential_multiplier=1000, wait_exponential_max=10000, stop_max_attempt_number=5)
+    @retry(wait_exponential_multiplier=constants.REQUEST_DELAY_MS, wait_exponential_max=10000, stop_max_attempt_number=5)
     def set_charge_amp_limit(self: object, amp_limit: int) -> dict:
         """Set the charge Amperage limit.
 

--- a/tesla_smart_charger/tesla_api.py
+++ b/tesla_smart_charger/tesla_api.py
@@ -1,21 +1,20 @@
-"""
-Tesla API class for Tesla Smart Charger.
-"""
+"""Tesla API class for Tesla Smart Charger."""
 
 import json
 
 import requests
+from fastapi import HTTPException
 from retrying import retry
 
-import tesla_smart_charger.constants as constants
+from tesla_smart_charger import constants
 from tesla_smart_charger.charger_config import ChargerConfig
 
 
 class TeslaAPI:
     """Tesla API class for Tesla Smart Charger.
 
-    Attributes:
-
+    Attributes
+    ----------
         charger_config (ChargerConfig): The charger configuration.
 
     """
@@ -24,18 +23,22 @@ class TeslaAPI:
         """Initialize the Tesla API.
 
         Args:
-
+        ----
             charger_config (ChargerConfig): The charger configuration.
 
         """
         self.charger_config = charger_config
 
-    @retry(wait_exponential_multiplier=constants.REQUEST_DELAY_MS, wait_exponential_max=10000, stop_max_attempt_number=5)
+    @retry(
+        wait_exponential_multiplier=constants.REQUEST_DELAY_MS,
+        wait_exponential_max=10000,
+        stop_max_attempt_number=5,
+    )
     def get_vehicles(self: object) -> dict:
         """Get the vehicles from the Tesla API.
 
-        Returns:
-
+        Returns
+        -------
             dict: The vehicles.
 
         """
@@ -43,41 +46,54 @@ class TeslaAPI:
         vehicle_request = requests.get(
             constants.TESLA_API_VEHICLES_URL,
             headers={
-                "Authorization": f"Bearer {self.charger_config.get_config().get('teslaAccessToken', None)}"
+                "Authorization": f"Bearer "
+                f"{self.charger_config.get_config().get('teslaAccessToken', None)}",
             },
+            timeout=20,
         )
 
         if vehicle_request.status_code != 200:
-            raise Exception("Request 'get_vehicles' failed with status code {}".format(vehicle_request.status_code))
+            msg = "Request 'get_vehicles' failed with status code {}".format(
+                vehicle_request.status_code,
+            )
+            raise HTTPException(vehicle_request.status_code, msg)
 
         response = json.loads(vehicle_request.text)
-        
+
         if constants.VERBOSE:
             print(response)
 
         return response["response"]
 
-
-    @retry(wait_exponential_multiplier=constants.REQUEST_DELAY_MS, wait_exponential_max=10000, stop_max_attempt_number=5)
+    @retry(
+        wait_exponential_multiplier=constants.REQUEST_DELAY_MS,
+        wait_exponential_max=10000,
+        stop_max_attempt_number=5,
+    )
     def get_vehicle_data(self: object) -> dict:
         """Get the vehicle data from the Tesla API.
 
-        Returns:
-
+        Returns
+        -------
             dict: The vehicle data.
 
         """
         # Get the vehicle data from the Tesla API
         vehicle_request = requests.get(
             constants.TESLA_API_VEHICLE_DATA_URL.format(
-                id=self.charger_config.get_config().get("teslaVehicleId", None)
+                id=self.charger_config.get_config().get("teslaVehicleId", None),
             ),
             headers={
-                "Authorization": f"Bearer {self.charger_config.get_config().get('teslaAccessToken', None)}"
+                "Authorization": f"Bearer "
+                f"{self.charger_config.get_config().get('teslaAccessToken', None)}",
             },
+            timeout=20,
         )
         if vehicle_request.status_code != 200:
-            raise Exception("Request 'get_vehicle_data' failed with status code {}".format(vehicle_request.status_code))
+            msg = "Request 'get_vehicle_data' failed with status code {}".format(
+                vehicle_request.status_code,
+            )
+            raise HTTPException(vehicle_request.status_code, msg)
 
         response = json.loads(vehicle_request.text)
 
@@ -86,35 +102,44 @@ class TeslaAPI:
 
         return response["response"]
 
-    @retry(wait_exponential_multiplier=constants.REQUEST_DELAY_MS, wait_exponential_max=10000, stop_max_attempt_number=5)
+    @retry(
+        wait_exponential_multiplier=constants.REQUEST_DELAY_MS,
+        wait_exponential_max=10000,
+        stop_max_attempt_number=5,
+    )
     def set_charge_amp_limit(self: object, amp_limit: int) -> dict:
         """Set the charge Amperage limit.
 
         Args:
-
+        ----
             amp_limit (int): The Amperage limit.
 
         Returns:
-
+        -------
             dict: The response.
 
         """
         # Set the charge Amperage limit
         charge_limit_request = requests.post(
             constants.TESLA_API_CHARGE_AMP_LIMIT_URL.format(
-                id=self.charger_config.get_config().get("teslaVehicleId", None)
+                id=self.charger_config.get_config().get("teslaVehicleId", None),
             ),
             headers={
-                "Authorization": f"Bearer {self.charger_config.get_config().get('teslaAccessToken', None)}"
+                "Authorization": f"Bearer "
+                f"{self.charger_config.get_config().get('teslaAccessToken', None)}",
             },
             json={"charging_amps": amp_limit},
+            timeout=20,
         )
         if charge_limit_request.status_code != 200:
-            raise Exception("Request 'set_charge_amp_limit' failed with status code {}".format(charge_limit_request.status_code))
+            msg = "Request 'set_charge_amp_limit' failed with status code {}".format(
+                charge_limit_request.status_code,
+            )
+            raise HTTPException(charge_limit_request.status_code, msg)
 
         response = json.loads(charge_limit_request.text)
 
         if constants.VERBOSE:
             print(response)
-        
+
         return response

--- a/tesla_smart_charger/token_cron.py
+++ b/tesla_smart_charger/token_cron.py
@@ -1,23 +1,20 @@
-"""
-Python script to run the token refresh cron job.
-"""
+"""Python script to run the token refresh cron job."""
 
 import json
-import requests
-import schedule
 import threading
 import time
 
-import tesla_smart_charger.constants as constants
+import requests
+import schedule
+
+from tesla_smart_charger import constants
 from tesla_smart_charger.charger_config import ChargerConfig
 
 charger_config = ChargerConfig(constants.CONFIG_FILE)
 
 
-def refresh_tesla_token():
-    """
-    Refresh the Tesla token
-    """
+def refresh_tesla_token() -> None:
+    """Refresh the Tesla token."""
     print("Refreshing token!")
     charger_config.load_config()
 
@@ -30,8 +27,10 @@ def refresh_tesla_token():
     print(refresh_json)
 
     # Request new token from Tesla API
-    token_request = requests.post(constants.TESLA_API_TOKEN_URL, json=refresh_json)
-    print("New Token : " + token_request.text)
+    token_request = requests.post(
+        constants.TESLA_API_TOKEN_URL, json=refresh_json, timeout=20,
+    )
+    print(f"New Token : {token_request.text}")
 
     # Parse the response
     token_response = json.loads(token_request.text)
@@ -43,10 +42,8 @@ def refresh_tesla_token():
     charger_config.set_config(json.dumps(charger_config.config))
 
 
-def start_cron_job(stop_event: threading.Event):
-    """
-    Starts the cron job to refresh the Tesla token
-    """
+def start_cron_job(stop_event: threading.Event) -> None:
+    """Start the cron job to refresh the Tesla token."""
     schedule.every(6).hours.do(refresh_tesla_token)
 
     while not stop_event.is_set():

--- a/tesla_smart_charger/utils.py
+++ b/tesla_smart_charger/utils.py
@@ -1,13 +1,11 @@
-"""
-Utility functions for tesla_smart_charger
-"""
+"""Utility functions for tesla_smart_charger."""
 
 
 def show_vehicles(vehicles: dict) -> None:
     """Show the vehicles.
 
     Args:
-
+    ----
         vehicles (dict): The vehicles.
 
     """

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Init file for tests directory."""

--- a/tests/test_charger_config.py
+++ b/tests/test_charger_config.py
@@ -1,21 +1,17 @@
-"""
-Tests for the charger_config module.
-"""
+"""Tests for the charger_config module."""
 
 import json
-
-from pydantic import BaseModel
+import pathlib
 
 import pytest
+from pydantic import BaseModel
 
 from tesla_smart_charger.charger_config import ChargerConfig
 
 
-@pytest.fixture
+@pytest.fixture()
 def config_file(tmp_path: str) -> str:
-    """
-    Create a temporary config file.
-    """
+    """Create a temporary config file."""
     config = {
         "homeMaxAmps": "11.0",
         "chargerMaxAmps": "11.0",
@@ -30,15 +26,13 @@ def config_file(tmp_path: str) -> str:
         "teslaRefreshToken": "0987654321",
     }
     config_file = tmp_path / "config.json"
-    with open(config_file, "w") as file:
+    with pathlib.Path.open(pathlib.Path(config_file), "w") as file:
         json.dump(config, file, indent=4)
     return config_file
 
 
 def test_load_config(config_file: str) -> None:
-    """
-    Test loading the config file.
-    """
+    """Test loading the config file."""
     tesla_config = ChargerConfig(config_file)
     tesla_config.load_config()
     assert tesla_config.get_config() == {
@@ -57,43 +51,35 @@ def test_load_config(config_file: str) -> None:
 
 
 def test_load_config_file_not_found() -> None:
-    """
-    Test loading a config file that does not exist.
-    """
+    """Test loading a config file that does not exist."""
     tesla_config = ChargerConfig("missing_config.json")
     assert tesla_config.load_config()["error"].startswith("Config file not found:")
 
 
 def test_load_config_file_not_valid_json(tmp_path: str) -> None:
-    """
-    Test loading a config file that is not valid JSON.
-    """
+    """Test loading a config file that is not valid JSON."""
     config_file = tmp_path / "config.json"
-    with open(config_file, "w") as file:
+    with pathlib.Path.open(pathlib.Path(config_file), "w") as file:
         file.write("not valid json")
     tesla_config = ChargerConfig(config_file)
     assert tesla_config.load_config()["error"].startswith(
-        "Config file is not valid JSON:"
+        "Config file is not valid JSON:",
     )
 
 
 def test_load_config_file_missing_required_key(tmp_path: str) -> None:
-    """
-    Test loading a config file that is missing a required key.
-    """
+    """Test loading a config file that is missing a required key."""
     config_file = tmp_path / "config.json"
-    with open(config_file, "w") as file:
+    with pathlib.Path.open(pathlib.Path(config_file), "w") as file:
         json.dump({"chargerMaxAmps": 11.0}, file, indent=4)
     tesla_config = ChargerConfig(config_file)
     assert tesla_config.load_config()["error"].startswith(
-        "Config file is not valid: Config file is missing required key: homeMaxAmps"
+        "Config file is not valid: Missing required config key: homeMaxAmps",
     )
 
 
 def test_get_config(config_file: str) -> None:
-    """
-    Test getting the config.
-    """
+    """Test getting the config."""
     tesla_config = ChargerConfig(config_file)
     tesla_config.load_config()
     assert tesla_config.get_config() == {
@@ -112,9 +98,7 @@ def test_get_config(config_file: str) -> None:
 
 
 def test_set_config(config_file: str) -> None:
-    """
-    Test setting the config.
-    """
+    """Test setting the config."""
     tesla_config = ChargerConfig(config_file)
     tesla_config.load_config()
 
@@ -164,20 +148,16 @@ def test_set_config(config_file: str) -> None:
 
 
 def test_set_config_missing_required_key(config_file: str) -> None:
-    """
-    Test setting the config with a config that is missing a required key.
-    """
+    """Test setting the config with a config that is missing a required key."""
     tesla_config = ChargerConfig(config_file)
     tesla_config.load_config()
     assert tesla_config.set_config({"chargerMaxAmps": 11.0})["error"].startswith(
-        "Config is not valid: Config file is missing required key: homeMaxAmps"
+        "Config is not valid: Missing required config key: homeMaxAmps",
     )
 
 
 def test_validate_config() -> None:
-    """
-    Test validating a config.
-    """
+    """Test validating a config."""
     tesla_config = ChargerConfig("config.json")
     tesla_config.load_config()
     tesla_config.validate_config(
@@ -193,15 +173,20 @@ def test_validate_config() -> None:
             "teslaVehicleId": "1234567890",
             "teslaAccessToken": "1234567890",
             "teslaRefreshToken": "0987654321",
-        }
+        },
     )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError): # noqa: PT011
         tesla_config.validate_config({"chargerMaxAmps": 11.0, "chargerMinAmps": 6.0})
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError): # noqa: PT011
         tesla_config.validate_config(
-            {"chargerMaxAmps": 11.0, "chargerMinAmps": 6.0, "downStepPercentage": 0.5}
+            {"chargerMaxAmps": 11.0, "chargerMinAmps": 6.0, "downStepPercentage": 0.5},
         )
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError): # noqa: PT011
         tesla_config.validate_config(
-            {"chargerMaxAmps": 11.0, "chargerMinAmps": 6.0, "downStepPercentage": 0.5, "upStepPercentage": 0.5}
+            {
+                "chargerMaxAmps": 11.0,
+                "chargerMinAmps": 6.0,
+                "downStepPercentage": 0.5,
+                "upStepPercentage": 0.5,
+            },
         )

--- a/tests/test_overload_handler.py
+++ b/tests/test_overload_handler.py
@@ -1,30 +1,28 @@
-"""
-Test the overload handler
-"""
-
-import pytest
+"""Test the overload handler."""
 
 from unittest.mock import patch
 
-import tesla_smart_charger.handlers.overload_handler as overload_handler
+import pytest
+
+from tesla_smart_charger.handlers import overload_handler
 
 
 @pytest.mark.parametrize(
-    "current_charge_limit, current_em_consumption, max_charge_limit, min_charge_limit, house_max_power, expected_new_charge_limit",
+    "current_charge_limit, current_em_consumption, max_charge_limit, min_charge_limit, house_max_power, expected_new_charge_limit", # noqa: E501, PT006
     [
         (16, 16, 16, 6, 16, 16),
         (15, 17, 16, 6, 16, 14),
         (15, 18, 16, 6, 16, 13),
         (12, 15, 16, 6, 16, 13),
         (20, 27, 25, 6, 32, 25),
-        (25, 35, 25, 6, 32, 22)
+        (25, 35, 25, 6, 32, 22),
     ],
 )
 @patch(
     "tesla_smart_charger.handlers.overload_handler.tesla_config.config",
     {"downStepPercentage": 0.5},
 )
-def test_calculate_new_charge_limit(
+def test_calculate_new_charge_limit( # noqa: PLR0913
     current_charge_limit: float,
     current_em_consumption: float,
     max_charge_limit: float,
@@ -32,11 +30,9 @@ def test_calculate_new_charge_limit(
     house_max_power: float,
     expected_new_charge_limit: float,
 ) -> None:
-    """
-    Test calculating the new charge limit
-    """
+    """Test calculating the new charge limit."""
     assert (
-        overload_handler._calculate_new_charge_limit(
+        overload_handler._calculate_new_charge_limit( # noqa: SLF001
             current_charge_limit,
             current_em_consumption,
             max_charge_limit,


### PR DESCRIPTION
Config must be loaded when overload starts and doing it during the full cycle ensures that token will be updated for long charging sessions

Issue: none