### PR TITLE
tesla-queries: reduce overload session time

### DIFF
--- a/tesla_smart_charger/constants.py
+++ b/tesla_smart_charger/constants.py
@@ -6,6 +6,9 @@ VERBOSE = False
 # Request delay in milliseconds
 REQUEST_DELAY_MS = 3000
 
+# Maximum number of queries to the Tesla API during overload handling session
+MAX_QUERIES = 20
+
 # Path to the configuration file
 CONFIG_FILE = "config.json"
 

--- a/tesla_smart_charger/handlers/overload_handler.py
+++ b/tesla_smart_charger/handlers/overload_handler.py
@@ -48,6 +48,7 @@ def handle_overload() -> None:
     """Handle the overload of the charger."""
     print("Handling overload!")
     print("Supervised session started!")
+    tesla_api_calls = 0
     # Instantiate the Energy Monitor controller
     try:
         em_controller = _em_controller.create_energy_monitor_controller(
@@ -77,6 +78,7 @@ def handle_overload() -> None:
     while (
         vehicle_data["state"] == "online"
         and vehicle_data["charge_state"]["charging_state"] == "Charging"
+        and tesla_api_calls < constants.MAX_QUERIES
     ):
         _reload_config()
         # Get the current charge limit in amps
@@ -114,8 +116,10 @@ def handle_overload() -> None:
                     status_code=e.status_code,
                     detail=f"Request failed: {e!s}",
                 ) from e
+            tesla_api_calls = 0
         else:
             print("No change in charge limit")
+            tesla_api_calls += 1
 
         # Sleep for the configured time
         time.sleep(int(tesla_config.config["sleepTimeSecs"]))


### PR DESCRIPTION
Overload session duration is now controlled by the number of times that the charging amps remain the same

Issue: none