### PR TITLE
em-cron: use host ip address to prevent connections issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Dynamic charging control for your Tesla using the default charger.
    - `sleepTimeSecs`: Time in seconds between each check after overload is detected.
    - `energyMonitorIp`: IP address or hostname of the Energy Monitor.
    - `energyMonitorType`: Type of Energy Monitor. Currently only `shelly-em` is supported.
+   - `hostIp`: IP address of the host machine. This is used to send overload notifications to the Energy Monitor thread.
+   - `apiPort`: Port where the Tesla Smart Charger API will be exposed.
    - `teslaVehicleId`: Vehicle ID obtained from the Tesla API.
    - `teslaAccessToken`: Access token obtained from the Tesla API.
    - `teslaRefreshToken`: Refresh token obtained from the Tesla API.
@@ -36,6 +38,8 @@ Dynamic charging control for your Tesla using the default charger.
       "sleepTimeSecs": 20,
       "energyMonitorIp": "ip-or-hostname",
       "energyMonitorType": "shelly-em",
+      "hostIp": "ip-address",
+      "apiPort": 8000,
       "teslaVehicleId": "12345678901234567",
       "teslaAccessToken": "12345678901234567",
       "teslaRefreshToken": "12345678901234567"
@@ -119,7 +123,7 @@ We welcome contributions to enhance the functionality and features of Tesla Smar
    ```  
 3. **Run Docker Container:**
    ```bash
-   docker run -it -p 8000:8000 -v ${PWD}:/app -d --network host --restart unless-stopped --name tesla tesla-smart-charger:latest
+   docker run -it -p 8000:8000 -v ${PWD}:/app -d --restart unless-stopped --name tesla tesla-smart-charger:latest
    ```
 
 Feel free to contribute and help make Tesla Smart Charger even better!

--- a/config.json
+++ b/config.json
@@ -7,6 +7,8 @@
     "sleepTimeSecs": "10",
     "energyMonitorIp": "ipAddress",
     "energyMonitorType": "shelly_em",
+    "hostIp": "ipAddress",
+    "apiPort": "8000",
     "teslaVehicleId": "12345",
     "teslaAccessToken": "12345",
     "teslaRefreshToken": "12345"

--- a/tesla_smart_charger/cron/em_cron.py
+++ b/tesla_smart_charger/cron/em_cron.py
@@ -59,10 +59,13 @@ def _check_power_consumption() -> None:
     ) and _toggle_overload(overload=True):
         print("Overload detected!")
         # Call the overload handler endpoint using requests
-        url = f"http://127.0.0.1:{tesla_config.config.get('apiPort', '8000')}/overload"
+        url = (
+            f"http://{tesla_config.config.get('hostIp', 'localhost')}:"
+            f"{tesla_config.config.get('apiPort', '8000')}/overload"
+        )
         try:
             requests.get(url, timeout=5)
-        except Exception as e: # noqa: BLE001
+        except Exception as e:  # noqa: BLE001
             print(f"Connection error: {e!s}")
             return
     else:


### PR DESCRIPTION
Using localhost is causing connection issues. Use host ip address to guarantee connection to own monitor thread.

Issue: none