### PR TITLE
http-proxy-url: use url from config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,15 @@ charging command to the vehicle.
    6. Generate a self-signed certificate:
        - Generate a self-signed certificate for tesla-http-proxy:
        ```bash
+       export HTTPS_PROXY=127.0.0.1 # The IP address of the host machine.
        openssl req -x509 -nodes -newkey ec \
-       -pkeyopt ec_paramgen_curve:secp521r1 \
-       -pkeyopt ec_param_enc:named_curve  \
-       -subj '/CN=localhost' \
-       -keyout tls-key.pem -out tls-cert.pem -sha256 -days 3650 \
-       -addext "subjectAltName = DNS:localhost" \
-       -addext "extendedKeyUsage = serverAuth" \
-       -addext "keyUsage = digitalSignature, keyCertSign, keyAgreement"
+        -pkeyopt ec_paramgen_curve:secp521r1 \
+        -pkeyopt ec_param_enc:named_curve \
+        -subj '/CN=localhost' \
+        -keyout tls-key.pem -out tls-cert.pem -sha256 -days 3650 \
+        -addext "subjectAltName = DNS:localhost, IP:$HTTPS_PROXY" \
+        -addext "extendedKeyUsage = serverAuth" \
+        -addext "keyUsage = digitalSignature, keyCertSign, keyAgreement"
        ```
    
    7. Start the tesla-http-proxy:

--- a/tesla_smart_charger/constants.py
+++ b/tesla_smart_charger/constants.py
@@ -1,10 +1,8 @@
 """Constants for the Tesla Smart Charger integration."""
 
-from pathlib import Path
-
 # Path to the certificate file
-TLS_CERT_PATH = f"{Path(__file__).resolve().parent.parent / 'certs' / 'tls-cert.pem'}"
-TLS_KEY_PATH = f"{Path(__file__).resolve().parent.parent / 'certs' / 'tls-key.pem'}"
+TLS_CERT_PATH = "certs/tls-cert.pem"
+TLS_KEY_PATH = "certs/tls-key.pem"
 
 # Verbose mode
 VERBOSE = False
@@ -55,21 +53,18 @@ REQUIRED_CONFIG_KEYS = [
     "teslaClientId",
 ]
 
-# Base URL for the Tesla API
-TESLA_API_BASE_URL = "https://localhost:4443"
-
 # URL for the Tesla API to get the access token
 TESLA_API_TOKEN_URL = "https://auth.tesla.com/oauth2/v3/token"
 
 # URL for the Tesla API to get the vehicle list
-TESLA_API_VEHICLES_URL = f"{TESLA_API_BASE_URL}/api/1/vehicles"
+TESLA_API_VEHICLES_URL = "/api/1/vehicles"
 
 # URL for the Tesla API to get the vehicle data
-TESLA_API_VEHICLE_DATA_URL = f"{TESLA_API_BASE_URL}/api/1/vehicles/{{id}}/vehicle_data"
+TESLA_API_VEHICLE_DATA_URL = f"/api/1/vehicles/{{id}}/vehicle_data" # noqa: F541
 
 # URL for the Tesla API to set the charging Amperage limit
 TESLA_API_CHARGE_AMP_LIMIT_URL = (
-    f"{TESLA_API_BASE_URL}/api/1/vehicles/{{id}}/command/set_charging_amps"
+    f"/api/1/vehicles/{{id}}/command/set_charging_amps" # noqa: F541
 )
 
 # Energy Monitor Controller states

--- a/tesla_smart_charger/tesla_api.py
+++ b/tesla_smart_charger/tesla_api.py
@@ -31,6 +31,7 @@ class TeslaAPI:
             The charger configuration.
         """
         self.charger_config = charger_config
+        self.http_proxy = self.charger_config.get_config().get("teslaHttpProxy", None)
 
     @retry(
         wait_exponential_multiplier=constants.REQUEST_DELAY_MS,
@@ -47,9 +48,10 @@ class TeslaAPI:
             The vehicles.
         """
         tsc_logger.info("Requesting vehicles from Tesla API.")
+
         try:
             vehicle_request = requests.get(
-                constants.TESLA_API_VEHICLES_URL,
+                f"{self.http_proxy}{constants.TESLA_API_VEHICLES_URL}",
                 headers={
                     "Authorization": f"Bearer {self.charger_config.get_config().get('teslaAccessToken')}",
                 },
@@ -89,7 +91,7 @@ class TeslaAPI:
 
         try:
             vehicle_request = requests.get(
-                constants.TESLA_API_VEHICLE_DATA_URL.format(id=vehicle_id),
+                f"{self.http_proxy}{constants.TESLA_API_VEHICLE_DATA_URL.format(id=vehicle_id)}",
                 headers={
                     "Authorization": f"Bearer {self.charger_config.get_config().get('teslaAccessToken')}",
                 },
@@ -136,7 +138,7 @@ class TeslaAPI:
 
         try:
             charge_limit_request = requests.post(
-                constants.TESLA_API_CHARGE_AMP_LIMIT_URL.format(id=vehicle_id),
+                f"{self.http_proxy}{constants.TESLA_API_CHARGE_AMP_LIMIT_URL.format(id=vehicle_id)}",
                 headers={
                     "Authorization": f"Bearer {self.charger_config.get_config().get('teslaAccessToken')}",
                 },


### PR DESCRIPTION
use config.json as source for setting composite URL