### PR TITLE
overload_handler.py: reduce api calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ charging command to the vehicle.
       "chargerMinAmps": 6.0,
       "downStepPercentage": 0.5,
       "upStepPercentage": 0.25,
-      "sleepTimeSecs": 20,
+      "sleepTimeSecs": 30,
       "energyMonitorIp": "ip-or-hostname",
       "energyMonitorType": "shelly-em",
       "hostIp": "ip-address",

--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
     "chargerMinAmps": "5.0",
     "downStepPercentage": "0.5",
     "upStepPercentage": "0.5",
-    "sleepTimeSecs": "10",
+    "sleepTimeSecs": "30",
     "energyMonitorIp": "ipAddress",
     "energyMonitorType": "shelly_em",
     "hostIp": "ipAddress",

--- a/tesla_smart_charger/constants.py
+++ b/tesla_smart_charger/constants.py
@@ -11,7 +11,7 @@ VERBOSE = False
 REQUEST_DELAY_MS = 3000
 
 # Maximum number of queries to the Tesla API during overload handling session
-MAX_QUERIES = 20
+MAX_QUERIES = 5
 
 # Path to the configuration file
 CONFIG_FILE = "config.json"
@@ -28,7 +28,7 @@ DEFAULT_CONFIG = {
     "upStepPercentage": "0.25",
     "energyMonitorIp": "",
     "energyMonitorType": "",
-    "sleepTimeSecs": "300",
+    "sleepTimeSecs": "30",
     "teslaVehicleId": "",
     "teslaAccessToken": "",
     "teslaRefreshToken": "",


### PR DESCRIPTION
Considering the API call limitations, we adopt a more conservative number of calls by allowing only 5 consecutive API calls.
If charging amps is set to max we also end the supervised session. Because many times the peaks are transitory and take less than 2min we wait for 10*sleep_time with MAX_AMPS set to half of the value without making any changes to charging_amps, hopefully the peak will pass and with only one more call we can get back to max and end the supervised session.