### PR TITLE
feat: bump golang build container to 1.23

### DIFF
--- a/Dockerfile.tesla-http-proxy
+++ b/Dockerfile.tesla-http-proxy
@@ -2,7 +2,7 @@
 ARG GIT_HASH=e8634aa8ac74282ab195edc462a86b1f87f451de
 
 # Build stage
-FROM golang:1.20 AS builder
+FROM golang:1.23 AS builder
 
 # Set the working directory inside the container
 WORKDIR /app


### PR DESCRIPTION
Version 1.23 is required to successully build the binary