### PR TITLE
fix(Dockerfile.tesla-smart-charger): replace --no-dev with --no-root

### DIFF
--- a/Dockerfile.tesla-smart-charger
+++ b/Dockerfile.tesla-smart-charger
@@ -22,7 +22,7 @@ WORKDIR /app
 COPY pyproject.toml poetry.lock ./
 
 # Install dependencies using Poetry
-RUN poetry install --no-dev
+RUN poetry install --no-root
 
 # Copy the application code
 COPY tesla_smart_charger tesla_smart_charger


### PR DESCRIPTION
Poetry does no longer support --no-dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chore**
	- Optimized the container build process by refining dependency installation, resulting in a more efficient setup without affecting end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->