### PR TITLE
fix: make vehicle status non-blocking on dashboard load; fix ruff config

### DIFF
--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -45,6 +45,9 @@ export interface VehicleStatus {
   chargingState: string | null
   chargerActualCurrent: number | null
   batteryLevel: number | null
+  // True while telemetry has never been fetched yet and a background
+  // refresh is in flight on the backend.
+  pending: boolean
 }
 
 /** Overall system status — GET /api/v1/status. */

--- a/dashboard/src/pages/Dashboard/index.tsx
+++ b/dashboard/src/pages/Dashboard/index.tsx
@@ -113,28 +113,30 @@ function VehicleCard({ vehicle: v }: { vehicle: VehicleStatus }) {
           <p className="font-semibold text-slate-900">{v.name || 'Tesla Vehicle'}</p>
           {v.vin && <p className="text-xs text-slate-400">VIN: {v.vin}</p>}
         </div>
-        <OnlineBadge online={v.online} />
+        {v.pending ? <Spinner size={16} /> : <OnlineBadge online={v.online} />}
       </div>
 
       <div className="space-y-3">
         <div className="flex justify-between text-sm">
           <span className="text-slate-500">Charging</span>
           <span className="font-medium text-slate-900">
-            {v.chargingState ?? '—'}
+            {v.pending ? 'Fetching…' : (v.chargingState ?? '—')}
           </span>
         </div>
         <div className="flex justify-between text-sm">
           <span className="text-slate-500">Current</span>
           <span className="font-medium text-slate-900">
-            {v.chargerActualCurrent != null
-              ? `${v.chargerActualCurrent} A`
-              : '—'}
+            {v.pending
+              ? 'Fetching…'
+              : v.chargerActualCurrent != null
+                ? `${v.chargerActualCurrent} A`
+                : '—'}
           </span>
         </div>
         <div className="flex justify-between text-sm">
           <span className="text-slate-500">Battery</span>
           <span className="font-medium text-slate-900">
-            {v.batteryLevel != null ? `${v.batteryLevel}%` : '—'}
+            {v.pending ? 'Fetching…' : v.batteryLevel != null ? `${v.batteryLevel}%` : '—'}
           </span>
         </div>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ tesla-smart-charger = "tesla_smart_charger.__main__:main"
 dev = [
     "black>=25.11.0",
     "pytest>=8.3.4",
-    "ruff>=0.15.10",
+    "ruff==0.16.0",
     "pytest-cov>=5.0.0",
     "tox>=4.23.2",
     "httpx2>=0.28.1",
@@ -67,7 +67,13 @@ testpaths = ["tests"]
 [toolpytest.cov]
 fail_under = 80
 
-[lint.ruff]
+[tool.ruff]
+target-version = "py310"
+# Same as Black.
+line-length = 88
+
+[tool.ruff.lint]
+select = ["ALL"]
 ignore = [
   "T201", # print() used
   "S104", # bind to all interfaces
@@ -78,21 +84,23 @@ ignore = [
   "PLR2004", # Use Magic Numbers
   "PLW0603", # Use of global statement
   "ERA001", # Found commented-out code
+  "COM812", # Trailing comma missing (conflicts with the formatter)
+  "D203", # 1 blank line required before class docstring (conflicts with D211, which we use)
+  "CPY001", # Missing copyright notice — this project doesn't use per-file copyright headers
 ]
 extend-ignore = ["N815"] # mixedCase variable in function scope
-lint.select = ["ALL"]
-target-version = "py310"
-# Same as Black.
-line-length = 88
 
-[lint.per-file-ignores]
-"tests/**/*.py" = ["S101"] # Use of assert detected.
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = [
+  "S101",   # Use of assert detected.
+  "SLF001", # Private member accessed (intentional white-box testing).
+]
 
-[lint.mccabe]
+[tool.ruff.lint.mccabe]
 # Implicit 10 is too low for our codebase, even black uses 18 as default.
 max-complexity = 20
 
-[lint.flake8-builtins]
+[tool.ruff.lint.flake8-builtins]
 builtins-ignorelist = ["id"]
 
 [tool.tox]
@@ -112,7 +120,7 @@ legacy_tox_ini = """
     
     [testenv:lint]
     deps =
-        ruff
+        ruff==0.16.0
     commands =
         ruff check tesla_smart_charger tests
     

--- a/tesla_smart_charger/__main__.py
+++ b/tesla_smart_charger/__main__.py
@@ -10,9 +10,9 @@ import asyncio
 import atexit
 import sys
 import threading
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Optional
 
 import uvicorn
 from fastapi import FastAPI, HTTPException
@@ -20,11 +20,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
-from tesla_smart_charger import constants, logger
+from tesla_smart_charger import constants, logger, utils
 from tesla_smart_charger.app_config import AppConfig
 from tesla_smart_charger.controllers import db_controller
 from tesla_smart_charger.cron import em_cron, token_cron
 from tesla_smart_charger.handlers import overload_handler
+from tesla_smart_charger.models import VehicleConfig
 from tesla_smart_charger.routes import (
     auth_routes,
     config_routes,
@@ -32,6 +33,7 @@ from tesla_smart_charger.routes import (
     status_routes,
     vehicle_routes,
 )
+from tesla_smart_charger.tesla_api import TeslaAPI
 
 # ─── Logging ──────────────────────────────────────────────────────────────────
 
@@ -47,14 +49,14 @@ app_config.load()
 stop_event = threading.Event()
 
 
-def _get_thread(name: str) -> Optional[threading.Thread]:
+def _get_thread(name: str) -> threading.Thread | None:
     for t in threading.enumerate():
         if t.name == name:
             return t
     return None
 
 
-def _start_thread(target, name: str, *extra_args) -> None:
+def _start_thread(target: Callable[..., None], name: str, *extra_args: object) -> None:
     t = threading.Thread(
         target=target, args=(stop_event, *extra_args), name=name, daemon=True
     )
@@ -68,6 +70,7 @@ def _monitor_active() -> bool:
 
 # ─── Database initialisation ───────────────────────────────────────────────────
 
+
 def _init_db(db_type: str) -> None:
     constants.DB_TYPE = db_type
     try:
@@ -77,15 +80,19 @@ def _init_db(db_type: str) -> None:
         ctrl.initialize_db()
         ctrl.close_connection()
         tsm_logger.info("Database initialised (%s).", db_type)
-    except Exception as exc:
-        tsm_logger.error("Database initialisation failed: %s", exc)
+    # Deliberately broad: any failure here is fatal at startup and must be
+    # logged before exiting, regardless of the underlying cause.
+    except Exception:
+        tsm_logger.exception("Database initialisation failed")
         sys.exit(1)
 
 
 # ─── FastAPI lifespan ──────────────────────────────────────────────────────────
 
+
 @asynccontextmanager
-async def lifespan(application: FastAPI):  # noqa: ARG001
+async def lifespan(_application: FastAPI) -> AsyncIterator[None]:
+    """Start background cron threads on startup and join them on shutdown."""
     tsm_logger.info("Tesla Smart Charger starting up.")
     _start_thread(token_cron.start_cron_token, "tsc_token_cron_thread", app_config)
     yield
@@ -129,6 +136,7 @@ app.include_router(history_routes.router)
 
 # ─── Legacy endpoints (kept for backward compatibility) ───────────────────────
 
+
 @app.get("/overload")
 def overload() -> JSONResponse:
     """
@@ -144,7 +152,10 @@ def overload() -> JSONResponse:
 
 @app.post("/underload")
 def underload() -> JSONResponse:
-    return JSONResponse({"msg": "underload session not yet implemented"}, status_code=501)
+    """Return a placeholder response for the not-yet-implemented underload endpoint."""
+    return JSONResponse(
+        {"msg": "underload session not yet implemented"}, status_code=501
+    )
 
 
 # ─── Static files — React dashboard ───────────────────────────────────────────
@@ -165,7 +176,10 @@ def serve_index() -> FileResponse:
     legacy = Path("tesla_smart_charger/website/index.html")
     if legacy.exists():
         return FileResponse(str(legacy))
-    raise HTTPException(status_code=503, detail="Dashboard not built. Run: cd dashboard && npm install && npm run build")
+    raise HTTPException(
+        status_code=503,
+        detail="Dashboard not built. Run: cd dashboard && npm install && npm run build",
+    )
 
 
 @app.get("/{full_path:path}")
@@ -187,6 +201,7 @@ def spa_catch_all(full_path: str) -> FileResponse:
 
 # ─── Exit handler ─────────────────────────────────────────────────────────────
 
+
 def _exit_handler() -> None:
     tsm_logger.info("Exit handler: cleanup complete.")
 
@@ -196,7 +211,19 @@ atexit.register(_exit_handler)
 
 # ─── CLI entry point ───────────────────────────────────────────────────────────
 
+
+def _print_tesla_vehicles(vehicle: VehicleConfig) -> None:
+    """Print the Tesla vehicles linked to *vehicle*'s OAuth token, or log on failure."""
+    try:
+        api = TeslaAPI(vehicle)
+        remote = api.get_vehicles()
+        utils.show_vehicles(remote)
+    except Exception:
+        tsm_logger.exception("Could not fetch vehicles for %s", vehicle.id)
+
+
 def main() -> None:
+    """Parse CLI args and either print the vehicle list or start the server."""
     parser = argparse.ArgumentParser(
         description="Tesla Smart Charger",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -211,7 +238,9 @@ def main() -> None:
         nargs="?",
         help="Print vehicle list from Tesla API and exit",
     )
-    parser.add_argument("-v", "--verbose", action="store_true", default=constants.VERBOSE)
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", default=constants.VERBOSE
+    )
 
     args = parser.parse_args()
 
@@ -223,22 +252,16 @@ def main() -> None:
         if not vehicles_list:
             print("No vehicles configured yet. Complete the onboarding wizard first.")
             sys.exit(0)
-        from tesla_smart_charger import utils
-        from tesla_smart_charger.tesla_api import TeslaAPI
-
         for v in vehicles_list:
-            try:
-                api = TeslaAPI(v)
-                remote = api.get_vehicles()
-                utils.show_vehicles(remote)
-            except Exception as exc:
-                tsm_logger.error("Could not fetch vehicles for %s: %s", v.id, exc)
+            _print_tesla_vehicles(v)
         sys.exit(0)
 
     _init_db(args.database)
 
     if args.monitor:
-        _start_thread(em_cron.start_cron_monitor, "tsc_energy_monitor_thread", app_config)
+        _start_thread(
+            em_cron.start_cron_monitor, "tsc_energy_monitor_thread", app_config
+        )
 
     uvicorn.run(app=app, host="0.0.0.0", port=args.port)
 

--- a/tesla_smart_charger/app_config.py
+++ b/tesla_smart_charger/app_config.py
@@ -3,10 +3,15 @@
 import json
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from tesla_smart_charger import logger
-from tesla_smart_charger.models import AuthConfig, SystemConfig, TeslaRegion, VehicleConfig
+from tesla_smart_charger.models import (
+    AuthConfig,
+    SystemConfig,
+    TeslaRegion,
+    VehicleConfig,
+)
 
 tsc_logger = logger.get_logger()
 
@@ -24,27 +29,32 @@ class AppConfig:
     """
 
     def __init__(self, config_dir: str = "config") -> None:
+        """Bind this manager to *config_dir* (not loaded until `load()` is called)."""
         self._config_dir = Path(config_dir)
         self._system_file = self._config_dir / "system.json"
         self._vehicles_file = self._config_dir / "vehicles.json"
         self._legacy_file = Path("config.json")
-        self._system: Optional[SystemConfig] = None
-        self._vehicles: List[VehicleConfig] = []
+        self._system: SystemConfig | None = None
+        self._vehicles: list[VehicleConfig] = []
 
     # ─── Properties ───────────────────────────────────────────────────────────
 
     @property
     def system(self) -> SystemConfig:
+        """Return the loaded system configuration."""
         if self._system is None:
-            raise RuntimeError("Configuration not loaded. Call load() first.")
+            msg = "Configuration not loaded. Call load() first."
+            raise RuntimeError(msg)
         return self._system
 
     @property
-    def vehicles(self) -> List[VehicleConfig]:
+    def vehicles(self) -> list[VehicleConfig]:
+        """Return the loaded list of vehicle configurations."""
         return self._vehicles
 
     @property
     def is_configured(self) -> bool:
+        """Return whether the onboarding wizard has been completed."""
         return self._system is not None and self._system.configured
 
     # ─── Load ─────────────────────────────────────────────────────────────────
@@ -70,8 +80,10 @@ class AppConfig:
         except FileNotFoundError:
             tsc_logger.info("system.json not found — using defaults.")
             self._system = SystemConfig()
-        except Exception as exc:
-            tsc_logger.error(f"Failed to load system.json: {exc}")
+        # Deliberately broad: any load/parse failure must fall back to
+        # defaults rather than prevent the app from starting.
+        except Exception:
+            tsc_logger.exception("Failed to load system.json")
             self._system = SystemConfig()
 
     def _load_vehicles(self) -> None:
@@ -80,19 +92,25 @@ class AppConfig:
                 raw = json.load(f)
             self._vehicles = [VehicleConfig(**v) for v in raw]
         except FileNotFoundError:
-            tsc_logger.info("vehicles.json not found — starting with empty vehicle list.")
+            tsc_logger.info(
+                "vehicles.json not found — starting with empty vehicle list."
+            )
             self._vehicles = []
-        except Exception as exc:
-            tsc_logger.error(f"Failed to load vehicles.json: {exc}")
+        # Deliberately broad: any load/parse failure must fall back to
+        # an empty vehicle list rather than prevent the app from starting.
+        except Exception:
+            tsc_logger.exception("Failed to load vehicles.json")
             self._vehicles = []
 
     def _migrate_from_legacy(self) -> None:
         """Migrate the old flat config.json → system.json + vehicles.json."""
         try:
             with self._legacy_file.open("r") as f:
-                old: Dict[str, Any] = json.load(f)
-        except Exception as exc:
-            tsc_logger.error(f"Migration failed — could not read config.json: {exc}")
+                old: dict[str, Any] = json.load(f)
+        # Deliberately broad: a corrupt/unreadable legacy file must fall back
+        # to defaults rather than prevent the app from starting.
+        except Exception:
+            tsc_logger.exception("Migration failed — could not read config.json")
             self._system = SystemConfig()
             return
 
@@ -158,20 +176,23 @@ class AppConfig:
 
     # ─── Vehicle CRUD ──────────────────────────────────────────────────────────
 
-    def get_vehicle(self, vehicle_id: str) -> Optional[VehicleConfig]:
+    def get_vehicle(self, vehicle_id: str) -> VehicleConfig | None:
+        """Return the vehicle with *vehicle_id*, or None if not found."""
         for v in self._vehicles:
             if v.id == vehicle_id:
                 return v
         return None
 
     def add_vehicle(self, vehicle: VehicleConfig) -> VehicleConfig:
+        """Append *vehicle* to the vehicle list and persist it."""
         self._vehicles.append(vehicle)
         self.save_vehicles()
         return vehicle
 
     def update_vehicle(
-        self, vehicle_id: str, updates: Dict[str, Any]
-    ) -> Optional[VehicleConfig]:
+        self, vehicle_id: str, updates: dict[str, Any]
+    ) -> VehicleConfig | None:
+        """Apply *updates* to the vehicle with *vehicle_id* and persist it."""
         for i, v in enumerate(self._vehicles):
             if v.id == vehicle_id:
                 updated = v.model_copy(update=updates)
@@ -181,6 +202,7 @@ class AppConfig:
         return None
 
     def remove_vehicle(self, vehicle_id: str) -> bool:
+        """Remove the vehicle with *vehicle_id*; return whether it was found."""
         original_len = len(self._vehicles)
         self._vehicles = [v for v in self._vehicles if v.id != vehicle_id]
         if len(self._vehicles) < original_len:
@@ -199,7 +221,7 @@ class AppConfig:
 
     # ─── System helpers ────────────────────────────────────────────────────────
 
-    def update_system(self, updates: Dict[str, Any]) -> SystemConfig:
+    def update_system(self, updates: dict[str, Any]) -> SystemConfig:
         """Merge *updates* into the system config and persist."""
         current = self._system.model_dump()
         # Handle nested auth updates

--- a/tesla_smart_charger/charger_config.py
+++ b/tesla_smart_charger/charger_config.py
@@ -1,9 +1,7 @@
 """Configurator class for Tesla Smart Charger."""
 
 import json
-
 from pathlib import Path
-from typing import Optional
 
 from tesla_smart_charger import constants
 
@@ -29,7 +27,7 @@ class ChargerConfig:
 
         """
         self.config_file = Path(config_file)
-        self.config: Optional[dict] = None
+        self.config: dict | None = None
 
     def load_config(self) -> dict:
         """
@@ -77,7 +75,7 @@ class ChargerConfig:
         ----
             config (dict): The configuration.
 
-        Returns
+        Returns:
         -------
             dict: The configuration.
 
@@ -93,7 +91,7 @@ class ChargerConfig:
                 return {"error": "Failed to load config after setting it."}
         except ValueError as error:
             return {"error": f"Config is not valid: {error}"}
-        except Exception as error:
+        except (OSError, TypeError) as error:
             return {"error": f"Failed to set config: {error}"}
         else:
             return self.config

--- a/tesla_smart_charger/constants.py
+++ b/tesla_smart_charger/constants.py
@@ -23,7 +23,8 @@ MAX_QUERIES = 5
 # ─── Config files ──────────────────────────────────────────────────────────────
 
 # New structured config directory.
-# Override via TESLA_CONFIG_DIR env var (e.g. TESLA_CONFIG_DIR=/data/tesla-smart-charger).
+# Override via TESLA_CONFIG_DIR env var
+# (e.g. TESLA_CONFIG_DIR=/data/tesla-smart-charger).
 CONFIG_DIR = os.getenv("TESLA_CONFIG_DIR", "config")
 SYSTEM_CONFIG_FILE = f"{CONFIG_DIR}/system.json"
 VEHICLES_CONFIG_FILE = f"{CONFIG_DIR}/vehicles.json"

--- a/tesla_smart_charger/controllers/db_controller.py
+++ b/tesla_smart_charger/controllers/db_controller.py
@@ -49,7 +49,9 @@ def create_database_controller(
     file_path: str,
 ) -> DatabaseController:
     """Create instances of DatabaseController based on the implementation_type."""
-    from tesla_smart_charger.controllers import sqlite_db_controller
+    # Imported locally to avoid a circular import: sqlite_db_controller imports
+    # DatabaseController from this module at module scope.
+    from tesla_smart_charger.controllers import sqlite_db_controller  # noqa: PLC0415
 
     if implementation_type == "sqlite":
         return sqlite_db_controller.SqliteDatabaseController(file_path, database)

--- a/tesla_smart_charger/controllers/em_controller.py
+++ b/tesla_smart_charger/controllers/em_controller.py
@@ -36,7 +36,9 @@ def create_energy_monitor_controller(
     host: str,
 ) -> EnergyMonitorController:
     """Create instances of EnergyMonitorController based on the implementation_type."""
-    from tesla_smart_charger.controllers import shelly_em_controller
+    # Imported locally to avoid a circular import: shelly_em_controller imports
+    # EnergyMonitorController from this module at module scope.
+    from tesla_smart_charger.controllers import shelly_em_controller  # noqa: PLC0415
 
     if implementation_type == "shelly_em":
         return shelly_em_controller.ShellyEMController(host)

--- a/tesla_smart_charger/controllers/shelly_em_controller.py
+++ b/tesla_smart_charger/controllers/shelly_em_controller.py
@@ -20,6 +20,7 @@ class ShellyEMController(EnergyMonitorController):
 
         Args:
             host (str): The IP address or hostname of the Shelly EM device.
+
         """
         self.type = "shelly_em"
         self.state = constants.EM_CONTROLLER_STATE_IDLE
@@ -35,6 +36,7 @@ class ShellyEMController(EnergyMonitorController):
 
         Returns:
             str: The current state of the controller.
+
         """
         return self.state
 
@@ -44,6 +46,7 @@ class ShellyEMController(EnergyMonitorController):
 
         Args:
             state (str): The new state of the controller.
+
         """
         self.state = state
 
@@ -61,13 +64,15 @@ class ShellyEMController(EnergyMonitorController):
 
         Raises:
             ValueError: If there is an error retrieving the consumption data.
+
         """
         try:
             response = requests.get(self.url, timeout=10)
             response.raise_for_status()  # Raises an HTTPError for bad responses
             data = response.json()
         except requests.RequestException as e:
-            raise ValueError(f"Error getting consumption: {e}") from e
+            msg = f"Error getting consumption: {e}"
+            raise ValueError(msg) from e
 
         # Save the last known consumption
         self.last_consumption = self.consumption

--- a/tesla_smart_charger/controllers/sqlite_db_controller.py
+++ b/tesla_smart_charger/controllers/sqlite_db_controller.py
@@ -1,5 +1,5 @@
 """
-SQLite DB Controller
+SQLite DB Controller.
 
 Stores and retrieves overload event records.
 Supports schema migration to add the vehicle_id column introduced in v2.
@@ -17,6 +17,7 @@ class SqliteDatabaseController(DatabaseController):
     """SQLite-backed implementation of DatabaseController."""
 
     def __init__(self, file_path: str, database: str) -> None:
+        """Bind this controller to a SQLite file (not opened until `initialize_db`)."""
         self.type = "sqlite"
         self.file_path = file_path
         self.database = database
@@ -50,8 +51,7 @@ class SqliteDatabaseController(DatabaseController):
 
             # Migrate: add vehicle_id column if missing (databases created before v2)
             existing_cols = {
-                row[1]
-                for row in self.cursor.execute("PRAGMA table_info(overloads)")
+                row[1] for row in self.cursor.execute("PRAGMA table_info(overloads)")
             }
             if "vehicle_id" not in existing_cols:
                 tsc_logger.info("Migrating overloads table: adding vehicle_id column.")
@@ -60,8 +60,8 @@ class SqliteDatabaseController(DatabaseController):
                 )
                 self.connection.commit()
 
-        except sqlite3.Error as exc:
-            tsc_logger.error("SQLite init error: %s", exc)
+        except sqlite3.Error:
+            tsc_logger.exception("SQLite init error")
             raise
 
     def close_connection(self) -> None:
@@ -94,14 +94,12 @@ class SqliteDatabaseController(DatabaseController):
             )
             self.connection.commit()
             tsc_logger.info("Overload event inserted.")
-        except sqlite3.Error as exc:
-            tsc_logger.error("SQLite insert error: %s", exc)
+        except sqlite3.Error:
+            tsc_logger.exception("SQLite insert error")
             raise
 
     def get_data(self, num_records: int = 10) -> list:
-        """
-        Return the most recent *num_records* overload events as dicts.
-        """
+        """Return the most recent *num_records* overload events as dicts."""
         try:
             self._ensure_open()
             self.cursor.execute(
@@ -115,8 +113,8 @@ class SqliteDatabaseController(DatabaseController):
             )
             rows = self.cursor.fetchall()
             return [dict(row) for row in rows]
-        except sqlite3.Error as exc:
-            tsc_logger.error("SQLite query error: %s", exc)
+        except sqlite3.Error:
+            tsc_logger.exception("SQLite query error")
             raise
 
     def get_data_filtered(
@@ -139,6 +137,7 @@ class SqliteDatabaseController(DatabaseController):
             Inclusive lower bound (``YYYY-MM-DD HH:MM:SS``).
         to_date : str
             Inclusive upper bound (``YYYY-MM-DD HH:MM:SS``).
+
         """
         try:
             self._ensure_open()
@@ -155,6 +154,9 @@ class SqliteDatabaseController(DatabaseController):
                 conditions.append("start <= ?")
                 params.append(to_date)
 
+            # `where` is built only from the fixed condition strings above
+            # (never from user input); all actual values are bound via the
+            # `?` placeholders in `params`, so this isn't a SQL-injection risk.
             where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
             params.append(num_records)
 
@@ -165,13 +167,13 @@ class SqliteDatabaseController(DatabaseController):
                 {where}
                 ORDER BY id DESC
                 LIMIT ?
-                """,
+                """,  # noqa: S608
                 params,
             )
             rows = self.cursor.fetchall()
             return [dict(row) for row in rows]
-        except sqlite3.Error as exc:
-            tsc_logger.error("SQLite filtered query error: %s", exc)
+        except sqlite3.Error:
+            tsc_logger.exception("SQLite filtered query error")
             raise
 
     def delete_data(self) -> None:
@@ -181,8 +183,8 @@ class SqliteDatabaseController(DatabaseController):
             self.cursor.execute("DELETE FROM overloads")
             self.connection.commit()
             tsc_logger.info("All overload records deleted.")
-        except sqlite3.Error as exc:
-            tsc_logger.error("SQLite delete error: %s", exc)
+        except sqlite3.Error:
+            tsc_logger.exception("SQLite delete error")
             raise
 
     def update_data(self, data: dict) -> None:
@@ -198,8 +200,8 @@ class SqliteDatabaseController(DatabaseController):
                 data,
             )
             self.connection.commit()
-        except sqlite3.Error as exc:
-            tsc_logger.error("SQLite update error: %s", exc)
+        except sqlite3.Error:
+            tsc_logger.exception("SQLite update error")
             raise
 
     # ─── Internal helpers ──────────────────────────────────────────────────────

--- a/tesla_smart_charger/cron/em_cron.py
+++ b/tesla_smart_charger/cron/em_cron.py
@@ -1,13 +1,13 @@
 """Energy-monitor polling cron — triggers overload handling when needed."""
 
 import threading
-from typing import Optional
 
 from retrying import retry
 
 from tesla_smart_charger import constants, logger
 from tesla_smart_charger.app_config import AppConfig
 from tesla_smart_charger.controllers import em_controller as _em_controller
+from tesla_smart_charger.controllers.em_controller import EnergyMonitorController
 from tesla_smart_charger.handlers import overload_handler
 
 tsc_logger = logger.get_logger()
@@ -18,10 +18,10 @@ OVERLOAD = False
 # Latest consumption reading in amps — written by the cron on each poll,
 # read by the status endpoint so the dashboard shows live home consumption.
 # Initialised to None so the dashboard shows "—" until the first poll.
-LAST_CONSUMPTION_AMPS: Optional[float] = None
+LAST_CONSUMPTION_AMPS: float | None = None
 
 
-def _toggle_overload(overload: bool) -> bool:
+def _toggle_overload(*, overload: bool) -> bool:
     """Set the OVERLOAD flag; returns True if the value changed."""
     global OVERLOAD
     if overload != OVERLOAD:
@@ -31,7 +31,7 @@ def _toggle_overload(overload: bool) -> bool:
     return False
 
 
-def _get_em_controller(app_config: AppConfig):
+def _get_em_controller(app_config: AppConfig) -> EnergyMonitorController | None:
     """Create and return an energy monitor controller, or None on failure."""
     cfg = app_config.system
     if not cfg.energyMonitorType or not cfg.energyMonitorIp:
@@ -45,8 +45,8 @@ def _get_em_controller(app_config: AppConfig):
         return _em_controller.create_energy_monitor_controller(
             cfg.energyMonitorType, cfg.energyMonitorIp
         )
-    except ValueError as exc:
-        tsc_logger.error("Invalid EM controller type: %s", exc)
+    except ValueError:
+        tsc_logger.exception("Invalid EM controller type")
         return None
 
 
@@ -55,23 +55,27 @@ def _get_em_controller(app_config: AppConfig):
     wait_exponential_max=10000,
     stop_max_attempt_number=3,
 )
-def _check_power_consumption(em_ctrl, app_config: AppConfig) -> None:
+def _check_power_consumption(
+    em_ctrl: EnergyMonitorController, app_config: AppConfig
+) -> None:
     """Poll the energy monitor and trigger overload handling if needed."""
     cfg = app_config.system
 
     try:
         watts = em_ctrl.get_consumption()
         if watts is None:
-            raise ValueError("EM returned None")
+            # Unify with the RequestException path below via one except block.
+            msg = "EM returned None"
+            raise ValueError(msg)  # noqa: TRY301
         em_amps = float(watts) / max(cfg.voltage, 1.0)
         tsc_logger.debug("Consumption: %.2f A (%.1f W)", em_amps, watts)
         global LAST_CONSUMPTION_AMPS
         LAST_CONSUMPTION_AMPS = em_amps
-    except (ValueError, TypeError) as exc:
-        tsc_logger.error("Error reading consumption: %s", exc)
+    except (ValueError, TypeError):
+        tsc_logger.exception("Error reading consumption")
         return
 
-    if em_amps > cfg.homeMaxAmps and _toggle_overload(True):
+    if em_amps > cfg.homeMaxAmps and _toggle_overload(overload=True):
         tsc_logger.warning(
             "Overload detected! %.2f A > %.2f A", em_amps, cfg.homeMaxAmps
         )
@@ -79,9 +83,9 @@ def _check_power_consumption(em_ctrl, app_config: AppConfig) -> None:
         started, msg = overload_handler.trigger_overload(app_config)
         if not started:
             tsc_logger.info("Overload trigger skipped: %s", msg)
-            _toggle_overload(False)  # Reset so next poll can retry
+            _toggle_overload(overload=False)  # Reset so next poll can retry
     else:
-        _toggle_overload(False)
+        _toggle_overload(overload=False)
 
 
 def start_cron_monitor(stop_event: threading.Event, app_config: AppConfig) -> None:
@@ -101,8 +105,10 @@ def start_cron_monitor(stop_event: threading.Event, app_config: AppConfig) -> No
         if countdown <= 0:
             try:
                 _check_power_consumption(em_ctrl, app_config)
-            except Exception as exc:
-                tsc_logger.error("Unhandled error in energy monitor poll: %s", exc)
+            # Deliberately broad: this is the cron loop's top-level guard —
+            # any unexpected error here must be logged, not crash the thread.
+            except Exception:
+                tsc_logger.exception("Unhandled error in energy monitor poll")
             countdown = check_interval
         stop_event.wait(sleep_tick)
         countdown -= sleep_tick

--- a/tesla_smart_charger/cron/token_cron.py
+++ b/tesla_smart_charger/cron/token_cron.py
@@ -8,8 +8,8 @@ from tesla_smart_charger.tesla_api import TeslaAPI
 
 tsc_logger = logger.get_logger()
 
-REFRESH_OK_INTERVAL = 10800   # 3 hours
-REFRESH_FAIL_INTERVAL = 300   # 5 minutes
+REFRESH_OK_INTERVAL = 10800  # 3 hours
+REFRESH_FAIL_INTERVAL = 300  # 5 minutes
 
 
 def refresh_all_tokens(app_config: AppConfig) -> bool:
@@ -68,8 +68,10 @@ def start_cron_token(stop_event: threading.Event, app_config: AppConfig) -> None
 
     try:
         success = refresh_all_tokens(app_config)
-    except Exception as exc:
-        tsc_logger.error("Initial token refresh failed unexpectedly: %s", exc)
+    # Deliberately broad: this is the cron loop's top-level guard — any
+    # unexpected error here must be logged, not crash the thread.
+    except Exception:
+        tsc_logger.exception("Initial token refresh failed unexpectedly")
         success = False
 
     interval = REFRESH_OK_INTERVAL if success else REFRESH_FAIL_INTERVAL
@@ -85,8 +87,10 @@ def start_cron_token(stop_event: threading.Event, app_config: AppConfig) -> None
                     interval,
                     "success" if success else "previous failure",
                 )
-            except Exception as exc:
-                tsc_logger.error("Unhandled error in token refresh: %s", exc)
+            # Deliberately broad: this is the cron loop's top-level guard —
+            # any unexpected error here must be logged, not crash the thread.
+            except Exception:
+                tsc_logger.exception("Unhandled error in token refresh")
                 interval = REFRESH_FAIL_INTERVAL
             countdown = interval
         stop_event.wait(sleep_tick)

--- a/tesla_smart_charger/handlers/overload_handler.py
+++ b/tesla_smart_charger/handlers/overload_handler.py
@@ -331,13 +331,13 @@ def _run_stabilisation_phase(
         time.sleep(cfg.sleepTimeSecs)
         cfg = app_config.system  # refresh
         em_amps = _get_consumption(em_ctrl, app_config)
-        if em_amps > cfg.homeMaxAmps:
-            tsc_logger.info("Overload still present after stabilisation wait.")
+        if em_amps <= cfg.homeMaxAmps:
+            tsc_logger.info(
+                "Consumption within limits during stabilisation — entering "
+                "adjustment loop."
+            )
             return
-        tsc_logger.info(
-            "Consumption within limits during stabilisation — entering adjustment loop."
-        )
-        return
+    tsc_logger.info("Overload still present after stabilisation wait.")
 
 
 def _apply_overload_reduction(

--- a/tesla_smart_charger/handlers/overload_handler.py
+++ b/tesla_smart_charger/handlers/overload_handler.py
@@ -1,9 +1,10 @@
 """Handles overload events — supports single or multiple charging vehicles."""
 
 import math
+import sqlite3
 import threading
 import time
-from typing import List, Optional, Tuple
+from dataclasses import dataclass
 
 from fastapi import HTTPException
 
@@ -11,7 +12,8 @@ from tesla_smart_charger import constants, logger
 from tesla_smart_charger.app_config import AppConfig
 from tesla_smart_charger.controllers import db_controller
 from tesla_smart_charger.controllers import em_controller as _em_controller
-from tesla_smart_charger.models import OverloadStrategy, VehicleConfig
+from tesla_smart_charger.controllers.em_controller import EnergyMonitorController
+from tesla_smart_charger.models import OverloadStrategy, SystemConfig, VehicleConfig
 from tesla_smart_charger.tesla_api import TeslaAPI
 
 tsc_logger = logger.get_logger()
@@ -22,11 +24,12 @@ _session_active = False
 
 
 def is_session_active() -> bool:
+    """Return whether an overload handling session is currently active."""
     with _session_lock:
         return _session_active
 
 
-def _set_session(active: bool) -> None:
+def _set_session(*, active: bool) -> None:
     global _session_active
     with _session_lock:
         _session_active = active
@@ -34,19 +37,23 @@ def _set_session(active: bool) -> None:
 
 # ─── Database helpers ──────────────────────────────────────────────────────────
 
-def _init_db() -> Optional[object]:
+
+def _init_db() -> object | None:
     try:
         ctrl = db_controller.create_database_controller(
             constants.DB_TYPE, constants.DB_NAME, constants.DB_FILE_PATH
         )
         ctrl.initialize_db()
-        return ctrl
-    except Exception as exc:
-        tsc_logger.error("Failed to initialise DB controller: %s", exc)
+    # Deliberately broad: any DB init failure must degrade to "no event
+    # logging" rather than break overload handling itself.
+    except Exception:
+        tsc_logger.exception("Failed to initialise DB controller")
         return None
+    else:
+        return ctrl
 
 
-def _save_event(start_time: str, vehicle_id: Optional[str] = None) -> None:
+def _save_event(start_time: str, vehicle_id: str | None = None) -> None:
     ctrl = _init_db()
     if ctrl is None:
         return
@@ -67,16 +74,19 @@ def _save_event(start_time: str, vehicle_id: Optional[str] = None) -> None:
             }
         )
         tsc_logger.info("Overload event saved to database.")
-    except Exception as exc:
-        tsc_logger.error("Error saving overload event: %s", exc)
+    # Deliberately broad: failing to save the event must not crash the
+    # overload handler's cleanup path.
+    except Exception:
+        tsc_logger.exception("Error saving overload event")
     finally:
         try:
             ctrl.close_connection()
-        except Exception as exc:
+        except sqlite3.Error as exc:
             tsc_logger.debug("Error closing DB connection: %s", exc)
 
 
 # ─── Calculation helpers ───────────────────────────────────────────────────────
+
 
 def _calculate_new_charge_limit(
     current_charge_limit: float,
@@ -107,24 +117,28 @@ def _calculate_new_charge_limit(
     return math.floor(new_limit)
 
 
-def _get_consumption(em_ctrl, app_config: AppConfig) -> float:
+def _get_consumption(em_ctrl: EnergyMonitorController, app_config: AppConfig) -> float:
     """Return current consumption in amps, 0.0 on error."""
     voltage = app_config.system.voltage
     try:
         watts = em_ctrl.get_consumption()
         amps = float(watts) / voltage
-        tsc_logger.debug("Current consumption: %.2f A (%.1f W / %.0f V)", amps, watts, voltage)
-        return amps
-    except (ValueError, TypeError, ZeroDivisionError) as exc:
-        tsc_logger.error("Error reading consumption: %s", exc)
+        tsc_logger.debug(
+            "Current consumption: %.2f A (%.1f W / %.0f V)", amps, watts, voltage
+        )
+    except (ValueError, TypeError, ZeroDivisionError):
+        tsc_logger.exception("Error reading consumption")
         return 0.0
+    else:
+        return amps
 
 
 # ─── Multi-vehicle overload strategies ────────────────────────────────────────
 
+
 def _get_charging_vehicles(
-    apis: List[Tuple[VehicleConfig, TeslaAPI]]
-) -> List[Tuple[VehicleConfig, TeslaAPI, dict]]:
+    apis: list[tuple[VehicleConfig, TeslaAPI]],
+) -> list[tuple[VehicleConfig, TeslaAPI, dict]]:
     """Return (vehicle, api, vehicle_data) tuples for all actively charging vehicles."""
     charging = []
     for vehicle, api in apis:
@@ -133,7 +147,9 @@ def _get_charging_vehicles(
         try:
             data = api.get_vehicle_data()
         except HTTPException:
-            tsc_logger.warning("Could not fetch data for vehicle %s — skipping.", vehicle.id)
+            tsc_logger.warning(
+                "Could not fetch data for vehicle %s — skipping.", vehicle.id
+            )
             continue
         if (
             data.get("state") == "online"
@@ -144,7 +160,7 @@ def _get_charging_vehicles(
 
 
 def _apply_proportional(
-    charging: List[Tuple[VehicleConfig, TeslaAPI, dict]],
+    charging: list[tuple[VehicleConfig, TeslaAPI, dict]],
     em_amps: float,
     home_max_amps: float,
 ) -> bool:
@@ -183,21 +199,20 @@ def _apply_proportional(
             try:
                 api.set_charge_amp_limit(new_limit)
                 changed = True
-            except HTTPException as exc:
-                tsc_logger.error(
-                    "Failed to set charge limit for %s: %s", vehicle.id, exc
-                )
+            except HTTPException:
+                tsc_logger.exception("Failed to set charge limit for %s", vehicle.id)
     return changed
 
 
 def _apply_priority(
-    charging: List[Tuple[VehicleConfig, TeslaAPI, dict]],
+    charging: list[tuple[VehicleConfig, TeslaAPI, dict]],
     em_amps: float,
     home_max_amps: float,
 ) -> bool:
     """
-    Reduce vehicles one at a time in reverse priority order
-    (lowest priority → highest priority) until overload is resolved.
+    Reduce vehicles one at a time in reverse priority order.
+
+    Order is lowest priority to highest priority, until overload is resolved.
 
     Returns True if at least one vehicle's limit was changed.
     """
@@ -224,16 +239,15 @@ def _apply_priority(
                 api.set_charge_amp_limit(new_limit)
                 remaining_excess -= reduction
                 changed = True
-            except HTTPException as exc:
-                tsc_logger.error(
-                    "Failed to set charge limit for %s: %s", vehicle.id, exc
-                )
+            except HTTPException:
+                tsc_logger.exception("Failed to set charge limit for %s", vehicle.id)
     return changed
 
 
 # ─── Public trigger (called by em_cron and the /overload HTTP endpoint) ────────
 
-def trigger_overload(app_config: AppConfig) -> Tuple[bool, str]:
+
+def trigger_overload(app_config: AppConfig) -> tuple[bool, str]:
     """
     Attempt to start an overload handling session.
 
@@ -271,8 +285,8 @@ def trigger_overload(app_config: AppConfig) -> Tuple[bool, str]:
             try:
                 api.set_charge_amp_limit(new_limit)
                 initial_applied = True
-            except HTTPException as exc:
-                tsc_logger.error("Initial downstep failed for %s: %s", vehicle.id, exc)
+            except HTTPException:
+                tsc_logger.exception("Initial downstep failed for %s", vehicle.id)
 
     if not initial_applied:
         return False, "no vehicles are currently charging"
@@ -289,6 +303,153 @@ def trigger_overload(app_config: AppConfig) -> Tuple[bool, str]:
 
 # ─── Main overload handler ────────────────────────────────────────────────────
 
+# Consecutive ramp-up iterations at max amp needed before ending the session.
+_CONSECUTIVE_MAX_NEEDED = 3
+
+
+@dataclass
+class _AdjustmentState:
+    """Mutable state carried across iterations of the supervised adjustment loop."""
+
+    no_change_count: int = 0
+    ramp_up: bool = False
+    ramp_up_start: float = 0.0
+    at_max_count: int = 0
+
+
+def _run_stabilisation_phase(
+    em_ctrl: EnergyMonitorController, app_config: AppConfig
+) -> None:
+    """
+    Wait up to 10 x sleep_time for consumption to stabilise after the first step.
+
+    If consumption drops within limits during this window we return early so
+    the main adjustment loop (which handles ramp-up) can take over.
+    """
+    cfg = app_config.system
+    for _ in range(10):
+        time.sleep(cfg.sleepTimeSecs)
+        cfg = app_config.system  # refresh
+        em_amps = _get_consumption(em_ctrl, app_config)
+        if em_amps > cfg.homeMaxAmps:
+            tsc_logger.info("Overload still present after stabilisation wait.")
+            return
+        tsc_logger.info(
+            "Consumption within limits during stabilisation — entering adjustment loop."
+        )
+        return
+
+
+def _apply_overload_reduction(
+    charging: list[tuple[VehicleConfig, TeslaAPI, dict]],
+    em_amps: float,
+    cfg: SystemConfig,
+    state: _AdjustmentState,
+) -> bool:
+    """Apply one overload-reduction iteration. Returns True to end the session."""
+    state.ramp_up = False
+    state.at_max_count = 0
+
+    if state.no_change_count >= constants.MAX_QUERIES:
+        tsc_logger.info(
+            "No change for %d consecutive iterations — ending session.",
+            state.no_change_count,
+        )
+        return True
+
+    # Check whether all vehicles are already at minimum before applying
+    all_at_min = all(
+        float(d["charge_state"]["charger_actual_current"]) <= v.chargerMinAmps
+        for v, _, d in charging
+    )
+    if all_at_min:
+        tsc_logger.info("All vehicles at minimum charge limit — ending session.")
+        return True
+
+    strategy = cfg.overloadStrategy
+    tsc_logger.info(
+        "Applying %s strategy | em=%.2fA | home_max=%.2fA | vehicles=%d",
+        strategy,
+        em_amps,
+        cfg.homeMaxAmps,
+        len(charging),
+    )
+
+    if strategy == OverloadStrategy.PRIORITY:
+        changed = _apply_priority(charging, em_amps, cfg.homeMaxAmps)
+    else:
+        changed = _apply_proportional(charging, em_amps, cfg.homeMaxAmps)
+
+    # Only count iterations where no adjustment could be made
+    if not changed:
+        state.no_change_count += 1
+    else:
+        state.no_change_count = 0  # reset on successful adjustment
+    return False
+
+
+def _apply_ramp_up(
+    charging: list[tuple[VehicleConfig, TeslaAPI, dict]],
+    em_amps: float,
+    cfg: SystemConfig,
+    state: _AdjustmentState,
+) -> bool:
+    """Apply one ramp-up iteration. Returns True to end the session."""
+    if not state.ramp_up:
+        state.ramp_up = True
+        state.ramp_up_start = time.time()
+        state.at_max_count = 0
+        tsc_logger.info(
+            "Consumption within limits (%.2fA ≤ %.2fA) — ramping up.",
+            em_amps,
+            cfg.homeMaxAmps,
+        )
+
+    # Ramp-up phase duration guard (cannot exceed maxSessionDuration)
+    if time.time() - state.ramp_up_start > cfg.maxSessionDuration:
+        tsc_logger.info("Ramp-up phase max duration reached — ending session.")
+        return True
+
+    # Try to increase charge limit for each vehicle
+    for vehicle, api, data in charging:
+        current = float(data["charge_state"]["charger_actual_current"])
+        if current >= vehicle.chargerMaxAmps:
+            continue
+        step = cfg.upStepPercentage * (vehicle.chargerMaxAmps - vehicle.chargerMinAmps)
+        new_limit = min(current + step, vehicle.chargerMaxAmps)
+        new_limit = max(int(vehicle.chargerMinAmps), math.floor(new_limit))
+        if new_limit > math.floor(current):
+            try:
+                api.set_charge_amp_limit(new_limit)
+                tsc_logger.info(
+                    "Ramping up %s: %.0fA → %.0fA",
+                    vehicle.name or vehicle.id,
+                    current,
+                    new_limit,
+                )
+            except HTTPException:
+                tsc_logger.exception("Failed to ramp up %s", vehicle.id)
+
+    # Check if all vehicles are at their configured max
+    all_at_max = all(
+        float(d["charge_state"]["charger_actual_current"]) >= v.chargerMaxAmps - 1.0
+        for v, _, d in charging
+    )
+    if all_at_max:
+        state.at_max_count += 1
+        tsc_logger.info(
+            "All vehicles at max amp — count %d/%d",
+            state.at_max_count,
+            _CONSECUTIVE_MAX_NEEDED,
+        )
+        if state.at_max_count >= _CONSECUTIVE_MAX_NEEDED:
+            tsc_logger.info("Overload resolved — ending session.")
+            return True
+    else:
+        state.at_max_count = 0
+    return False
+
+
 def handle_overload(app_config: AppConfig) -> None:
     """
     Top-level overload handler — runs in a dedicated thread.
@@ -297,19 +458,14 @@ def handle_overload(app_config: AppConfig) -> None:
     to all actively-charging vehicles.  Logs the event to the database.
     The session flag is always cleared in a finally block, even on error.
     """
-    _set_session(True)
+    _set_session(active=True)
     start_time = time.strftime("%Y-%m-%d %H:%M:%S")
     tsc_logger.info("Overload handler started. Supervised session begun.")
 
     # Keep a reference to the last known charging set so _save_event can use it
-    charging: List[Tuple[VehicleConfig, TeslaAPI, dict]] = []
+    charging: list[tuple[VehicleConfig, TeslaAPI, dict]] = []
 
     try:
-        # Build (VehicleConfig, TeslaAPI) pairs for every enabled vehicle
-        apis: List[Tuple[VehicleConfig, TeslaAPI]] = [
-            (v, TeslaAPI(v)) for v in app_config.vehicles if v.enabled
-        ]
-
         cfg = app_config.system
 
         # Instantiate energy monitor
@@ -318,30 +474,16 @@ def handle_overload(app_config: AppConfig) -> None:
                 cfg.energyMonitorType, cfg.energyMonitorIp
             )
         except ValueError:
-            tsc_logger.error("Invalid energy monitor type '%s'.", cfg.energyMonitorType)
+            tsc_logger.exception(
+                "Invalid energy monitor type '%s'.", cfg.energyMonitorType
+            )
             return
 
-        # ── Stabilisation phase ──────────────────────────────────────────────
-        # Wait up to 10 × sleep_time for consumption to stabilise after first step.
-        # If consumption drops within limits during this window we break early so
-        # the main adjustment loop (which handles ramp-up) can take over.
-        for _ in range(10):
-            time.sleep(cfg.sleepTimeSecs)
-            cfg = app_config.system  # refresh
-            em_amps = _get_consumption(em_ctrl, app_config)
-            if em_amps > cfg.homeMaxAmps:
-                tsc_logger.info("Overload still present after stabilisation wait.")
-                break
-            tsc_logger.info("Consumption within limits during stabilisation — entering adjustment loop.")
-            break
+        _run_stabilisation_phase(em_ctrl, app_config)
 
         # ── Supervised adjustment loop ───────────────────────────────────────
-        no_change_count = 0
+        state = _AdjustmentState()
         session_start_ts = time.time()
-        ramp_up = False
-        ramp_up_start = 0.0
-        at_max_count = 0
-        CONSECUTIVE_MAX_NEEDED = 3
 
         while True:
             cfg = app_config.system  # always act on fresh config
@@ -369,111 +511,21 @@ def handle_overload(app_config: AppConfig) -> None:
                 break
 
             if em_amps > cfg.homeMaxAmps:
-                # ── OVERLOAD STILL PRESENT — apply reduction ───────────────
-                ramp_up = False
-                at_max_count = 0
-
-                if no_change_count >= constants.MAX_QUERIES:
-                    tsc_logger.info(
-                        "No change for %d consecutive iterations — ending session.",
-                        no_change_count,
-                    )
-                    break
-
-                # Check whether all vehicles are already at minimum before applying
-                all_at_min = all(
-                    float(d["charge_state"]["charger_actual_current"]) <= v.chargerMinAmps
-                    for v, _, d in charging
-                )
-                if all_at_min:
-                    tsc_logger.info("All vehicles at minimum charge limit — ending session.")
-                    break
-
-                strategy = cfg.overloadStrategy
-                tsc_logger.info(
-                    "Applying %s strategy | em=%.2fA | home_max=%.2fA | vehicles=%d",
-                    strategy,
-                    em_amps,
-                    cfg.homeMaxAmps,
-                    len(charging),
-                )
-
-                if strategy == OverloadStrategy.PRIORITY:
-                    changed = _apply_priority(charging, em_amps, cfg.homeMaxAmps)
-                else:
-                    changed = _apply_proportional(charging, em_amps, cfg.homeMaxAmps)
-
-                # Only count iterations where no adjustment could be made
-                if not changed:
-                    no_change_count += 1
-                else:
-                    no_change_count = 0  # reset on successful adjustment
+                session_ended = _apply_overload_reduction(charging, em_amps, cfg, state)
             else:
-                # ── CONSUMPTION WITHIN LIMITS — ramp back up ──────────────
-                if not ramp_up:
-                    ramp_up = True
-                    ramp_up_start = time.time()
-                    at_max_count = 0
-                    tsc_logger.info(
-                        "Consumption within limits (%.2fA ≤ %.2fA) — ramping up.",
-                        em_amps,
-                        cfg.homeMaxAmps,
-                    )
-
-                # Ramp-up phase duration guard (cannot exceed maxSessionDuration)
-                if time.time() - ramp_up_start > cfg.maxSessionDuration:
-                    tsc_logger.info(
-                        "Ramp-up phase max duration reached — ending session.",
-                    )
-                    break
-
-                # Try to increase charge limit for each vehicle
-                for vehicle, api, data in charging:
-                    current = float(data["charge_state"]["charger_actual_current"])
-                    if current >= vehicle.chargerMaxAmps:
-                        continue
-                    step = cfg.upStepPercentage * (vehicle.chargerMaxAmps - vehicle.chargerMinAmps)
-                    new_limit = min(current + step, vehicle.chargerMaxAmps)
-                    new_limit = max(int(vehicle.chargerMinAmps), math.floor(new_limit))
-                    if new_limit > math.floor(current):
-                        try:
-                            api.set_charge_amp_limit(new_limit)
-                            tsc_logger.info(
-                                "Ramping up %s: %.0fA → %.0fA",
-                                vehicle.name or vehicle.id,
-                                current,
-                                new_limit,
-                            )
-                        except HTTPException as exc:
-                            tsc_logger.error(
-                                "Failed to ramp up %s: %s", vehicle.id, exc,
-                            )
-
-                # Check if all vehicles are at their configured max
-                all_at_max = all(
-                    float(d["charge_state"]["charger_actual_current"]) >= v.chargerMaxAmps - 1.0
-                    for v, _, d in charging
-                )
-                if all_at_max:
-                    at_max_count += 1
-                    tsc_logger.info(
-                        "All vehicles at max amp — count %d/%d",
-                        at_max_count,
-                        CONSECUTIVE_MAX_NEEDED,
-                    )
-                    if at_max_count >= CONSECUTIVE_MAX_NEEDED:
-                        tsc_logger.info("Overload resolved — ending session.")
-                        break
-                else:
-                    at_max_count = 0
+                session_ended = _apply_ramp_up(charging, em_amps, cfg, state)
+            if session_ended:
+                break
 
             time.sleep(cfg.sleepTimeSecs)
 
-    except Exception as exc:
-        tsc_logger.error("Unhandled error in overload handler: %s", exc)
+    # Deliberately broad: this is the thread's top-level guard — any
+    # unexpected error must be logged, not crash the thread silently.
+    except Exception:
+        tsc_logger.exception("Unhandled error in overload handler")
     finally:
         # Always persist the event and release the session lock
         first_vid = charging[0][0].id if charging else None
         _save_event(start_time, first_vid)
-        _set_session(False)
+        _set_session(active=False)
         tsc_logger.info("Overload handler finished. Supervised session ended.")

--- a/tesla_smart_charger/handlers/overload_handler.py
+++ b/tesla_smart_charger/handlers/overload_handler.py
@@ -306,6 +306,15 @@ def trigger_overload(app_config: AppConfig) -> tuple[bool, str]:
 # Consecutive ramp-up iterations at max amp needed before ending the session.
 _CONSECUTIVE_MAX_NEEDED = 3
 
+# Consecutive in-limit readings needed during stabilisation before treating
+# the overload as resolved — guards against a single transient dip.
+_STABLE_READINGS_NEEDED = 3
+
+# Base stabilisation wait window, in iterations. A bad reading on the very
+# last base iteration would otherwise leave no room to confirm a streak, so
+# the loop runs for this many iterations plus a little slack (see below).
+_STABILISATION_BASE_ITERATIONS = 10
+
 
 @dataclass
 class _AdjustmentState:
@@ -321,22 +330,34 @@ def _run_stabilisation_phase(
     em_ctrl: EnergyMonitorController, app_config: AppConfig
 ) -> None:
     """
-    Wait up to 10 x sleep_time for consumption to stabilise after the first step.
+    Wait for consumption to stabilise after the first downstep.
 
-    If consumption drops within limits during this window we return early so
+    Requires _STABLE_READINGS_NEEDED consecutive in-limit readings before
+    returning early — a single low reading could be a transient dip rather
+    than genuine resolution, so any reading back above the limit resets the
+    streak. Runs for up to _STABILISATION_BASE_ITERATIONS x sleep_time, plus
+    a little slack so a bad reading near the end still leaves room to
+    confirm a streak. If the window elapses without one, falls through so
     the main adjustment loop (which handles ramp-up) can take over.
     """
     cfg = app_config.system
-    for _ in range(10):
+    consecutive_ok = 0
+    max_iterations = _STABILISATION_BASE_ITERATIONS + _STABLE_READINGS_NEEDED - 1
+    for _ in range(max_iterations):
         time.sleep(cfg.sleepTimeSecs)
         cfg = app_config.system  # refresh
         em_amps = _get_consumption(em_ctrl, app_config)
         if em_amps <= cfg.homeMaxAmps:
-            tsc_logger.info(
-                "Consumption within limits during stabilisation — entering "
-                "adjustment loop."
-            )
-            return
+            consecutive_ok += 1
+            if consecutive_ok >= _STABLE_READINGS_NEEDED:
+                tsc_logger.info(
+                    "Consumption within limits for %d consecutive reads — "
+                    "entering adjustment loop.",
+                    consecutive_ok,
+                )
+                return
+        else:
+            consecutive_ok = 0
     tsc_logger.info("Overload still present after stabilisation wait.")
 
 

--- a/tesla_smart_charger/logger.py
+++ b/tesla_smart_charger/logger.py
@@ -38,10 +38,9 @@ def get_logger(
         console_handler.setFormatter(formatter)
         logger.addHandler(console_handler)
 
-        if log_file := DEFAULT_LOG_FILE:
+        if log_file:
             file_handler = logging.FileHandler(log_file)
-
-        file_handler.setFormatter(formatter)
-        logger.addHandler(file_handler)
+            file_handler.setFormatter(formatter)
+            logger.addHandler(file_handler)
 
     return logger

--- a/tesla_smart_charger/logger.py
+++ b/tesla_smart_charger/logger.py
@@ -1,13 +1,14 @@
+"""Logging setup for the Tesla Smart Charger application."""
+
 import logging
 import os
 import sys
-
 
 DEFAULT_LOG_FILE = "tesla-smart-charger.log"
 
 
 def get_logger(
-    name: str = __name__, verbose: bool = False, log_file: str = DEFAULT_LOG_FILE
+    name: str = __name__, *, verbose: bool = False, log_file: str = DEFAULT_LOG_FILE
 ) -> logging.Logger:
     """
     Set up a logger instance and return it.
@@ -19,6 +20,7 @@ def get_logger(
 
     Returns:
         logger: logging.Logger - the logger instance
+
     """
     if "TSM_VERBOSE" in os.environ:
         verbose = True

--- a/tesla_smart_charger/models.py
+++ b/tesla_smart_charger/models.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import uuid
 from enum import Enum
-from typing import List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -21,7 +20,9 @@ class OverloadStrategy(str, Enum):
     """Strategy for distributing load reduction across multiple vehicles."""
 
     PROPORTIONAL = "proportional"  # All vehicles reduced proportionally
-    PRIORITY = "priority"  # Vehicles reduced in priority order (1 = highest, reduce last)
+    PRIORITY = (
+        "priority"  # Vehicles reduced in priority order (1 = highest, reduce last)
+    )
 
 
 class AuthConfig(BaseModel):
@@ -62,15 +63,18 @@ class SystemConfig(BaseModel):
     downStepPercentage: float = 0.5
     upStepPercentage: float = 0.25
     overloadStrategy: OverloadStrategy = OverloadStrategy.PROPORTIONAL
-    maxSessionDuration: int = 600  # Maximum supervised session duration in seconds (default 10 min)
+    maxSessionDuration: int = (
+        600  # Maximum supervised session duration in seconds (default 10 min)
+    )
     hostIp: str = "localhost"
     apiPort: int = 8000
-    corsOrigins: List[str] = Field(default_factory=lambda: ["*"])
+    corsOrigins: list[str] = Field(default_factory=lambda: ["*"])
     auth: AuthConfig = Field(default_factory=AuthConfig)
     configured: bool = False  # Set to True after completing the onboarding wizard
 
 
 # ─── API response models ───────────────────────────────────────────────────────
+
 
 class VehicleStatus(BaseModel):
     """Live status for a vehicle, merged with its config."""
@@ -85,10 +89,14 @@ class VehicleStatus(BaseModel):
     priority: int
     enabled: bool
     # Live fields (None when vehicle is offline / not reachable)
-    online: Optional[bool] = None
-    chargingState: Optional[str] = None
-    chargerActualCurrent: Optional[float] = None
-    batteryLevel: Optional[int] = None
+    online: bool | None = None
+    chargingState: str | None = None
+    chargerActualCurrent: float | None = None
+    batteryLevel: int | None = None
+    # True while telemetry has never been fetched yet and a background
+    # refresh is in flight — lets clients distinguish "still fetching"
+    # from "checked and it's offline".
+    pending: bool = False
 
 
 class SystemStatus(BaseModel):
@@ -97,7 +105,7 @@ class SystemStatus(BaseModel):
     configured: bool
     monitorActive: bool
     overloadActive: bool
-    currentConsumptionAmps: Optional[float] = None
+    currentConsumptionAmps: float | None = None
     homeMaxAmps: float
     region: str
     voltage: float

--- a/tesla_smart_charger/routes/auth_routes.py
+++ b/tesla_smart_charger/routes/auth_routes.py
@@ -19,7 +19,7 @@ import secrets
 import threading
 import time
 import urllib.parse
-from typing import Any, Dict, Optional
+from typing import Annotated, Any
 
 import requests
 from fastapi import APIRouter, HTTPException, Query
@@ -28,23 +28,25 @@ from pydantic import BaseModel
 
 from tesla_smart_charger import constants, logger
 from tesla_smart_charger.app_config import AppConfig
+from tesla_smart_charger.models import VehicleConfig
+from tesla_smart_charger.tesla_api import TeslaAPI
 
 tsc_logger = logger.get_logger()
 
 router = APIRouter(tags=["auth"])
 
-_app_config: Optional[AppConfig] = None
+_app_config: AppConfig | None = None
 
 # In-memory PKCE state store: state_token → {code_verifier, vehicle_id, expires_at}
 # Guarded by _oauth_sessions_lock — concurrent /auth/start and /auth/callback
 # requests run in FastAPI's threadpool and mutate this dict.
-_oauth_sessions: Dict[str, Dict[str, Any]] = {}
+_oauth_sessions: dict[str, dict[str, Any]] = {}
 _oauth_sessions_lock = threading.Lock()
 SESSION_TTL = 600  # 10 minutes
 
 # Completed OAuth results keyed by state so the frontend can retrieve them
 # via a manual paste-URL fallback when postMessage / hash delivery fails.
-_oauth_results: Dict[str, Dict[str, Any]] = {}
+_oauth_results: dict[str, dict[str, Any]] = {}
 _oauth_results_lock = threading.Lock()
 RESULT_TTL = 300  # 5 minutes
 
@@ -62,14 +64,17 @@ _ALLOWED_TOKEN_ISSUERS = (
 
 
 def init(app_config: AppConfig) -> None:
+    """Inject the shared AppConfig instance used by this router."""
     global _app_config
     _app_config = app_config
 
 
 def _validate_proxy_url(proxy_url: str) -> None:
     """
-    Reject obviously unsafe proxy URLs before they are used to build outbound,
-    token-bearing requests. Requires an http/https scheme and a host.
+    Reject obviously unsafe proxy URLs.
+
+    Applied before they are used to build outbound, token-bearing requests.
+    Requires an http/https scheme and a host.
 
     Also rejects loopback / link-local IP addresses to limit SSRF surface,
     while allowing private (RFC1918) IPs since the proxy typically runs on
@@ -93,10 +98,13 @@ def _validate_proxy_url(proxy_url: str) -> None:
         pass  # hostname, not an IP — can't validate further without DNS
 
 
-def _callback_html(payload: Optional[Dict[str, Any]] = None, error: Optional[str] = None) -> str:
+def _callback_html(
+    payload: dict[str, Any] | None = None, error: str | None = None
+) -> str:
     """
-    Return an HTML page that posts an OAuth result to the opener window via
-    ``window.postMessage`` and immediately closes itself.
+    Return an HTML page that posts an OAuth result to the opener window.
+
+    Uses ``window.postMessage`` and immediately closes itself.
 
     This page is loaded inside the Tesla OAuth popup that the onboarding wizard
     opens.  After the server completes the token exchange it embeds the result
@@ -162,7 +170,8 @@ def _callback_html(payload: Optional[Dict[str, Any]] = None, error: Optional[str
         }} else {{
           document.getElementById('msg').className = 'err';
           document.getElementById('msg').textContent =
-            'Could not communicate with the opener window. Please close this tab and try again.';
+            'Could not communicate with the opener window. ' +
+            'Please close this tab and try again.';
         }}
       }} catch(e) {{
         document.getElementById('msg').className = 'err';
@@ -178,6 +187,7 @@ def _callback_html(payload: Optional[Dict[str, Any]] = None, error: Optional[str
 
 
 # ─── PKCE helpers ──────────────────────────────────────────────────────────────
+
 
 def _generate_code_verifier() -> str:
     return base64.urlsafe_b64encode(os.urandom(40)).rstrip(b"=").decode()
@@ -198,9 +208,14 @@ def _clean_expired_sessions() -> None:
 
 # ─── OAuth flow ────────────────────────────────────────────────────────────────
 
+
 class AuthStartBody(BaseModel):
-    """Body for /auth/start — credentials sent in POST body to avoid leaking
-    the client_secret into server access logs, browser history, or proxies."""
+    """
+    Body for /auth/start.
+
+    Credentials are sent in the POST body to avoid leaking the client_secret
+    into server access logs, browser history, or proxies.
+    """
 
     client_id: str
     client_secret: str = ""
@@ -247,10 +262,14 @@ def auth_start(body: AuthStartBody) -> JSONResponse:
     return JSONResponse({"auth_url": auth_url, "state": state}, status_code=200)
 
 
-def _perform_token_exchange(code: str, state: str, issuer: Optional[str] = None) -> Dict[str, Any]:
+def _perform_token_exchange(
+    code: str, state: str, issuer: str | None = None
+) -> dict[str, Any]:
     """
-    Look up the PKCE session, exchange the authorization code for tokens,
-    and return the result payload dict.
+    Exchange the authorization code for tokens.
+
+    Looks up the PKCE session, exchanges the code for tokens, and returns
+    the result payload dict.
 
     The ``issuer`` is taken from the callback URL's ``issuer`` query param
     (e.g. ``https://auth.tesla.com/oauth2/v3``).  The token endpoint is
@@ -302,8 +321,10 @@ def _perform_token_exchange(code: str, state: str, issuer: Optional[str] = None)
         r.raise_for_status()
         tokens = r.json()
     except requests.RequestException as exc:
-        tsc_logger.error("Token exchange failed: %s", exc)
-        raise HTTPException(status_code=502, detail=f"Token exchange failed: {exc}") from exc
+        tsc_logger.exception("Token exchange failed")
+        raise HTTPException(
+            status_code=502, detail=f"Token exchange failed: {exc}"
+        ) from exc
 
     access = tokens.get("access_token", "")
     refresh = tokens.get("refresh_token", "")
@@ -313,9 +334,6 @@ def _perform_token_exchange(code: str, state: str, issuer: Optional[str] = None)
 
     vehicles_list: list = []
     try:
-        from tesla_smart_charger.models import VehicleConfig
-        from tesla_smart_charger.tesla_api import TeslaAPI
-
         tmp_vehicle = VehicleConfig(
             teslaAccessToken=access,
             teslaRefreshToken=refresh,
@@ -325,10 +343,13 @@ def _perform_token_exchange(code: str, state: str, issuer: Optional[str] = None)
         )
         api = TeslaAPI(tmp_vehicle)
         vehicles_list = api.get_vehicles()
-    except Exception as exc:
-        tsc_logger.warning("Could not list vehicles after OAuth: %s", exc)
+    # Deliberately broad: failing to list vehicles must not fail the OAuth
+    # exchange itself — the tokens are still valid and already stored below.
+    # Logged at WARNING (not ERROR) since this path is non-fatal.
+    except Exception:
+        tsc_logger.warning("Could not list vehicles after OAuth.", exc_info=True)
 
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "access_token": access,
         "refresh_token": refresh,
         "client_id": session["client_id"],
@@ -346,23 +367,31 @@ def _perform_token_exchange(code: str, state: str, issuer: Optional[str] = None)
     return payload
 
 
-def _handle_auth_callback(code: str, state: str, issuer: Optional[str] = None) -> HTMLResponse:
-    """Shared OAuth callback logic — called by both /auth/callback and
-    user-configured redirect URIs (e.g. /done.html)."""
+def _handle_auth_callback(
+    code: str, state: str, issuer: str | None = None
+) -> HTMLResponse:
+    """
+    Run the shared OAuth callback logic.
+
+    Called by both /auth/callback and user-configured redirect URIs
+    (e.g. /done.html).
+    """
     try:
         payload = _perform_token_exchange(code, state, issuer=issuer)
     except HTTPException as exc:
         return HTMLResponse(_callback_html(error=exc.detail))
-    except Exception as exc:
+    # Deliberately broad: this always renders an HTML error page for the
+    # popup window rather than letting any error type propagate as a 500.
+    except Exception as exc:  # noqa: BLE001
         return HTMLResponse(_callback_html(error=str(exc)))
     return HTMLResponse(_callback_html(payload=payload))
 
 
 @router.get("/auth/callback")
 def auth_callback(
-    code: str = Query(...),
-    state: str = Query(...),
-    issuer: Optional[str] = Query(None),
+    code: Annotated[str, Query()],
+    state: Annotated[str, Query()],
+    issuer: Annotated[str | None, Query()] = None,
 ) -> HTMLResponse:
     """
     OAuth callback — exchanges the authorization code for access/refresh tokens.
@@ -381,10 +410,11 @@ def auth_callback(
 # before the SPA catch-all in __main__.py this route takes precedence.
 @router.get("/done.html")
 def auth_callback_done(
-    code: str = Query(...),
-    state: str = Query(...),
-    issuer: Optional[str] = Query(None),
+    code: Annotated[str, Query()],
+    state: Annotated[str, Query()],
+    issuer: Annotated[str | None, Query()] = None,
 ) -> HTMLResponse:
+    """Alias of /auth/callback for custom-configured Tesla redirect URIs."""
     return _handle_auth_callback(code, state, issuer=issuer)
 
 
@@ -408,12 +438,16 @@ def get_auth_result(state: str) -> JSONResponse:
 
 
 class OAuthExchangeBody(BaseModel):
+    """Body for /auth/exchange — a pasted OAuth callback's code and state."""
+
     code: str
     state: str
-    issuer: Optional[str] = None
+    issuer: str | None = None
 
 
 class OAuthVehiclesBody(BaseModel):
+    """Body for /auth/vehicles — credentials to list vehicles with."""
+
     access_token: str
     proxy_url: str
     region: str = "eu"
@@ -422,12 +456,12 @@ class OAuthVehiclesBody(BaseModel):
 @router.post("/auth/exchange")
 def exchange_auth_code(body: OAuthExchangeBody) -> JSONResponse:
     """
-    Manually exchange an authorization code for tokens using the pasted
-    callback URL from the popup.
+    Manually exchange an authorization code for tokens.
 
-    This is the manual fallback for when the user's reverse proxy serves a
-    static file at the redirect URI path (e.g. ``/done.html``) instead of
-    forwarding the request to the backend.  The user copies the callback URL
+    Used with the pasted callback URL from the popup as the manual fallback
+    for when the user's reverse proxy serves a static file at the redirect
+    URI path (e.g. ``/done.html``) instead of forwarding the request to the
+    backend.  The user copies the callback URL
     from the popup's address bar and pastes it into the main window; the
     frontend extracts ``code`` and ``state`` and calls this endpoint.
     """
@@ -444,14 +478,12 @@ def exchange_auth_code(body: OAuthExchangeBody) -> JSONResponse:
 def list_oauth_vehicles(body: OAuthVehiclesBody) -> JSONResponse:
     """
     Return the list of Tesla vehicles accessible with the provided token.
+
     Used during onboarding to let the user pick vehicles to manage.
 
     Credentials are sent in the request body (never the query string) to avoid
     leaking the access token into access logs / proxy caches.
     """
-    from tesla_smart_charger.models import VehicleConfig
-    from tesla_smart_charger.tesla_api import TeslaAPI
-
     _validate_proxy_url(body.proxy_url)
     tmp_vehicle = VehicleConfig(
         teslaAccessToken=body.access_token,
@@ -468,20 +500,28 @@ def list_oauth_vehicles(body: OAuthVehiclesBody) -> JSONResponse:
 
 # ─── Basic Auth management ─────────────────────────────────────────────────────
 
+
 class AuthSetupBody(BaseModel):
+    """Body for /api/v1/auth/setup — enable/disable Basic Auth and credentials."""
+
     enabled: bool
-    username: Optional[str] = None
-    password: Optional[str] = None
+    username: str | None = None
+    password: str | None = None
 
 
 class AuthVerifyBody(BaseModel):
+    """Body for /api/v1/auth/verify — a username/password to check."""
+
     username: str
     password: str
 
 
 def _hash_password(password: str) -> str:
     try:
-        import bcrypt
+        # Imported locally so ImportError can be caught here and fall back —
+        # a top-level import would fail at module load instead.
+        import bcrypt  # noqa: PLC0415
+
         return bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
     except ImportError:
         # Fallback: SHA-256 (less secure, but avoids hard dependency)
@@ -490,7 +530,8 @@ def _hash_password(password: str) -> str:
 
 def _check_password(password: str, hashed: str) -> bool:
     try:
-        import bcrypt
+        import bcrypt  # noqa: PLC0415
+
         return bcrypt.checkpw(password.encode(), hashed.encode())
     except ImportError:
         return hashlib.sha256(password.encode()).hexdigest() == hashed
@@ -502,7 +543,7 @@ def setup_auth(body: AuthSetupBody) -> JSONResponse:
     if _app_config is None:
         raise HTTPException(status_code=503, detail="Not initialised")
 
-    updates: Dict[str, Any] = {"auth": {"enabled": body.enabled}}
+    updates: dict[str, Any] = {"auth": {"enabled": body.enabled}}
 
     if body.enabled:
         if not body.username or not body.password:

--- a/tesla_smart_charger/routes/config_routes.py
+++ b/tesla_smart_charger/routes/config_routes.py
@@ -92,7 +92,8 @@ def test_energy_monitor(body: TestEnergyMonitorBody) -> JSONResponse:
             {
                 "ok": False,
                 "error": str(exc),
-            }
+            },
+            status_code=400,
         )
 
 

--- a/tesla_smart_charger/routes/config_routes.py
+++ b/tesla_smart_charger/routes/config_routes.py
@@ -1,9 +1,9 @@
 """GET /api/v1/config  and  POST /api/v1/config — system configuration."""
 
 import ipaddress
-import requests
-from typing import Any, Dict, Optional
+from typing import Any
 
+import requests
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
@@ -16,10 +16,11 @@ tsc_logger = logger.get_logger()
 
 router = APIRouter(prefix="/api/v1", tags=["config"])
 
-_app_config: Optional[AppConfig] = None
+_app_config: AppConfig | None = None
 
 
 def init(app_config: AppConfig) -> None:
+    """Inject the shared AppConfig instance used by this router."""
     global _app_config
     _app_config = app_config
 
@@ -34,19 +35,19 @@ class TestEnergyMonitorBody(BaseModel):
 class SystemConfigUpdate(BaseModel):
     """Partial system config update body — all fields optional."""
 
-    homeMaxAmps: Optional[float] = None
-    voltage: Optional[float] = None
-    region: Optional[TeslaRegion] = None
-    energyMonitorIp: Optional[str] = None
-    energyMonitorType: Optional[str] = None
-    sleepTimeSecs: Optional[int] = None
-    downStepPercentage: Optional[float] = None
-    upStepPercentage: Optional[float] = None
-    overloadStrategy: Optional[OverloadStrategy] = None
-    maxSessionDuration: Optional[int] = None
-    hostIp: Optional[str] = None
-    apiPort: Optional[int] = None
-    configured: Optional[bool] = None
+    homeMaxAmps: float | None = None
+    voltage: float | None = None
+    region: TeslaRegion | None = None
+    energyMonitorIp: str | None = None
+    energyMonitorType: str | None = None
+    sleepTimeSecs: int | None = None
+    downStepPercentage: float | None = None
+    upStepPercentage: float | None = None
+    overloadStrategy: OverloadStrategy | None = None
+    maxSessionDuration: int | None = None
+    hostIp: str | None = None
+    apiPort: int | None = None
+    configured: bool | None = None
 
 
 @router.post("/test-energy-monitor")
@@ -60,29 +61,39 @@ def test_energy_monitor(body: TestEnergyMonitorBody) -> JSONResponse:
     try:
         ip = ipaddress.ip_address(body.ip)
         if ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved:
-            return JSONResponse({
-                "ok": False,
-                "error": f"IP {body.ip} is not allowed.",
-            }, status_code=400)
+            return JSONResponse(
+                {
+                    "ok": False,
+                    "error": f"IP {body.ip} is not allowed.",
+                },
+                status_code=400,
+            )
     except ValueError:
-        return JSONResponse({
-            "ok": False,
-            "error": f"Invalid IP address: {body.ip}",
-        }, status_code=400)
+        return JSONResponse(
+            {
+                "ok": False,
+                "error": f"Invalid IP address: {body.ip}",
+            },
+            status_code=400,
+        )
 
     try:
         r = requests.get(f"http://{body.ip}/status/", timeout=10)
         r.raise_for_status()
         data = r.json()
-        return JSONResponse({
-            "ok": True,
-            "emeters": len(data.get("emeters", [])),
-        })
+        return JSONResponse(
+            {
+                "ok": True,
+                "emeters": len(data.get("emeters", [])),
+            }
+        )
     except requests.RequestException as exc:
-        return JSONResponse({
-            "ok": False,
-            "error": str(exc),
-        })
+        return JSONResponse(
+            {
+                "ok": False,
+                "error": str(exc),
+            }
+        )
 
 
 @router.get("/config")
@@ -102,7 +113,7 @@ def update_config(body: SystemConfigUpdate) -> JSONResponse:
     """Merge provided fields into the system configuration and persist."""
     if _app_config is None:
         raise HTTPException(status_code=503, detail="Not initialised")
-    updates: Dict[str, Any] = {
+    updates: dict[str, Any] = {
         k: v for k, v in body.model_dump().items() if v is not None
     }
     if not updates:

--- a/tesla_smart_charger/routes/history_routes.py
+++ b/tesla_smart_charger/routes/history_routes.py
@@ -1,5 +1,7 @@
 """GET /api/v1/history — paginated, filterable overload event history."""
 
+import sqlite3
+from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import JSONResponse
@@ -14,10 +16,16 @@ router = APIRouter(prefix="/api/v1", tags=["history"])
 
 @router.get("/history")
 def get_history(
-    limit: int = Query(50, ge=1, le=500, description="Maximum records to return"),
-    vehicle_id: str = Query("", description="Filter by vehicle UUID"),
-    from_date: str = Query("", description="Lower bound (YYYY-MM-DD HH:MM:SS)"),
-    to_date: str = Query("", description="Upper bound (YYYY-MM-DD HH:MM:SS)"),
+    limit: Annotated[
+        int, Query(ge=1, le=500, description="Maximum records to return")
+    ] = 50,
+    vehicle_id: Annotated[str, Query(description="Filter by vehicle UUID")] = "",
+    from_date: Annotated[
+        str, Query(description="Lower bound (YYYY-MM-DD HH:MM:SS)")
+    ] = "",
+    to_date: Annotated[
+        str, Query(description="Upper bound (YYYY-MM-DD HH:MM:SS)")
+    ] = "",
 ) -> JSONResponse:
     """Return filtered overload event history."""
     ctrl = None
@@ -37,19 +45,20 @@ def get_history(
             data = ctrl.get_data(limit)
         return JSONResponse({"data": data, "count": len(data)}, status_code=200)
     except Exception as exc:
-        tsc_logger.error("History query failed: %s", exc)
+        tsc_logger.exception("History query failed")
         raise HTTPException(status_code=500, detail="Database error") from exc
     finally:
         if ctrl:
             try:
                 ctrl.close_connection()
-            except Exception as exc:
+            except sqlite3.Error as exc:
                 tsc_logger.debug("Error closing DB connection: %s", exc)
 
 
 # Backward-compatible endpoint kept for legacy em_cron self-calls
 @router.get("/history/{num_records}")
 def get_history_legacy(num_records: int) -> JSONResponse:
+    """Return the most recent overload event records (legacy, unfiltered)."""
     ctrl = None
     try:
         ctrl = db_controller.create_database_controller(
@@ -64,5 +73,5 @@ def get_history_legacy(num_records: int) -> JSONResponse:
         if ctrl:
             try:
                 ctrl.close_connection()
-            except Exception as exc:
+            except sqlite3.Error as exc:
                 tsc_logger.debug("Error closing DB connection: %s", exc)

--- a/tesla_smart_charger/routes/status_routes.py
+++ b/tesla_smart_charger/routes/status_routes.py
@@ -1,8 +1,8 @@
 """GET /api/v1/status — overall system health and live state."""
 
-import time
 import threading
-from typing import Callable, Dict, Optional
+import time
+from collections.abc import Callable
 
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
@@ -10,7 +10,7 @@ from fastapi.responses import JSONResponse
 from tesla_smart_charger import logger
 from tesla_smart_charger.app_config import AppConfig
 from tesla_smart_charger.cron import em_cron
-from tesla_smart_charger.models import SystemStatus, VehicleStatus
+from tesla_smart_charger.models import SystemStatus, VehicleConfig, VehicleStatus
 from tesla_smart_charger.tesla_api import TeslaAPI
 
 tsc_logger = logger.get_logger()
@@ -18,9 +18,9 @@ tsc_logger = logger.get_logger()
 router = APIRouter(prefix="/api/v1", tags=["status"])
 
 # References injected by __main__
-_app_config: Optional[AppConfig] = None
+_app_config: AppConfig | None = None
 _monitor_active: bool = False
-_overload_active_fn: Optional[Callable[[], bool]] = None
+_overload_active_fn: Callable[[], bool] | None = None
 
 # ─── Per-vehicle telemetry cache ───────────────────────────────────────────────
 # Stores (timestamp, VehicleStatus) per vehicle id.  Entries are served from
@@ -28,25 +28,29 @@ _overload_active_fn: Optional[Callable[[], bool]] = None
 # so we don't spam the Tesla API waking them up every 30 seconds.
 _CACHE_TTL_ONLINE_SECS = 30
 _CACHE_TTL_OFFLINE_SECS = 300  # 5 min
-_cache: Dict[str, tuple] = {}          # vehicle_id → (fetched_at, VehicleStatus)
+_cache: dict[str, tuple] = {}  # vehicle_id → (fetched_at, VehicleStatus)
 _cache_lock = threading.Lock()
 
+# vehicle ids with a background refresh currently in flight — prevents piling
+# up duplicate Tesla API calls for the same vehicle while one is already running.
+_pending: set = set()
+_pending_lock = threading.Lock()
 
-def init(app_config: AppConfig, monitor_active_fn, overload_active_fn) -> None:
+
+def init(
+    app_config: AppConfig,
+    monitor_active_fn: Callable[[], bool],
+    overload_active_fn: Callable[[], bool],
+) -> None:
+    """Inject the shared AppConfig and state-check callbacks used by this router."""
     global _app_config, _monitor_active, _overload_active_fn
     _app_config = app_config
     _monitor_active = monitor_active_fn
     _overload_active_fn = overload_active_fn
 
 
-def _live_vehicle_status(vehicle) -> VehicleStatus:
-    """
-    Return live telemetry for a vehicle.
-
-    Results are cached for ``_CACHE_TTL_SECS`` seconds to avoid hammering
-    the Tesla API on every dashboard refresh.
-    """
-    base = VehicleStatus(
+def _base_vehicle_status(vehicle: VehicleConfig) -> VehicleStatus:
+    return VehicleStatus(
         id=vehicle.id,
         name=vehicle.name,
         vin=vehicle.vin,
@@ -58,10 +62,48 @@ def _live_vehicle_status(vehicle) -> VehicleStatus:
         enabled=vehicle.enabled,
         online=False,
     )
+
+
+def _refresh_vehicle_status(vehicle: VehicleConfig) -> None:
+    """
+    Fetch live telemetry for a vehicle and update the cache.
+
+    Runs on a background thread so it never blocks a request.
+    """
+    status = _base_vehicle_status(vehicle)
+    try:
+        api = TeslaAPI(vehicle)
+        data = api.get_vehicle_data()
+        status.online = data.get("state") == "online"
+        charge = data.get("charge_state", {})
+        status.chargingState = charge.get("charging_state")
+        status.chargerActualCurrent = charge.get("charger_actual_current")
+        status.batteryLevel = charge.get("battery_level")
+    # Deliberately broad: this runs on a background thread and must never
+    # crash — `finally` below always caches a result either way.
+    except Exception:
+        tsc_logger.exception("Live telemetry fetch failed for vehicle %s", vehicle.id)
+    finally:
+        with _cache_lock:
+            _cache[vehicle.id] = (time.monotonic(), status)
+        with _pending_lock:
+            _pending.discard(vehicle.id)
+
+
+def _live_vehicle_status(vehicle: VehicleConfig) -> VehicleStatus:
+    """
+    Return the best currently-known telemetry for a vehicle.
+
+    Never blocks on the network: serves cached data (fresh or stale)
+    immediately, kicking off a background refresh whenever the cache entry
+    is missing or has expired. Callers always get an instant response; a
+    stale/placeholder result is replaced in the cache the next time this
+    endpoint is polled once the background fetch completes.
+    """
+    base = _base_vehicle_status(vehicle)
     if not vehicle.enabled or not vehicle.teslaVehicleId:
         return base
 
-    # Serve from cache when the entry is still fresh.
     # Offline vehicles get a longer TTL to avoid waking them unnecessarily.
     # During an active overload session we use the shorter online TTL even for
     # offline vehicles so the dashboard reflects live charge-limit changes sooner.
@@ -71,29 +113,33 @@ def _live_vehicle_status(vehicle) -> VehicleStatus:
         cached = _cache.get(vehicle.id)
         if cached is not None:
             fetched_at, cached_status = cached
-            ttl = _CACHE_TTL_ONLINE_SECS if (cached_status.online or overload_active) else _CACHE_TTL_OFFLINE_SECS
-            if now - fetched_at < ttl:
-                return cached_status
+            ttl = (
+                _CACHE_TTL_ONLINE_SECS
+                if (cached_status.online or overload_active)
+                else _CACHE_TTL_OFFLINE_SECS
+            )
+            is_fresh = now - fetched_at < ttl
+        else:
+            is_fresh = False
 
-    # Cache miss (or stale) — fetch live data
-    try:
-        api = TeslaAPI(vehicle)
-        data = api.get_vehicle_data()
-        base.online = data.get("state") == "online"
-        charge = data.get("charge_state", {})
-        base.chargingState = charge.get("charging_state")
-        base.chargerActualCurrent = charge.get("charger_actual_current")
-        base.batteryLevel = charge.get("battery_level")
-    except Exception as exc:
-        tsc_logger.warning(
-            "Live telemetry fetch failed for vehicle %s: %s",
-            vehicle.id,
-            exc,
-        )
+    if cached is not None and is_fresh:
+        return cached_status
 
-    with _cache_lock:
-        _cache[vehicle.id] = (now, base)
+    # Cache is missing or stale — kick off a background refresh (unless one
+    # is already in flight) and return the best data we have right now.
+    with _pending_lock:
+        already_pending = vehicle.id in _pending
+        if not already_pending:
+            _pending.add(vehicle.id)
+    if not already_pending:
+        threading.Thread(
+            target=_refresh_vehicle_status, args=(vehicle,), daemon=True
+        ).start()
 
+    if cached is not None:
+        return cached_status
+
+    base.pending = True
     return base
 
 
@@ -108,8 +154,12 @@ def get_status() -> JSONResponse:
 
     status = SystemStatus(
         configured=cfg.configured,
-        monitorActive=_monitor_active() if callable(_monitor_active) else _monitor_active,
-        overloadActive=_overload_active_fn() if callable(_overload_active_fn) else False,
+        monitorActive=_monitor_active()
+        if callable(_monitor_active)
+        else _monitor_active,
+        overloadActive=_overload_active_fn()
+        if callable(_overload_active_fn)
+        else False,
         currentConsumptionAmps=em_cron.LAST_CONSUMPTION_AMPS,
         homeMaxAmps=cfg.homeMaxAmps,
         region=cfg.region.value,

--- a/tesla_smart_charger/routes/vehicle_routes.py
+++ b/tesla_smart_charger/routes/vehicle_routes.py
@@ -1,6 +1,6 @@
 """Vehicle CRUD endpoints — /api/v1/vehicles."""
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import JSONResponse
@@ -15,10 +15,11 @@ tsc_logger = logger.get_logger()
 
 router = APIRouter(prefix="/api/v1/vehicles", tags=["vehicles"])
 
-_app_config: Optional[AppConfig] = None
+_app_config: AppConfig | None = None
 
 
 def init(app_config: AppConfig) -> None:
+    """Inject the shared AppConfig instance used by this router."""
     global _app_config
     _app_config = app_config
 
@@ -43,13 +44,13 @@ class VehicleCreate(BaseModel):
 class VehicleUpdate(BaseModel):
     """Partial vehicle update — all fields optional."""
 
-    name: Optional[str] = None
-    chargerMaxAmps: Optional[float] = None
-    chargerMinAmps: Optional[float] = None
-    priority: Optional[int] = None
-    enabled: Optional[bool] = None
-    teslaHttpProxy: Optional[str] = None
-    teslaClientId: Optional[str] = None
+    name: str | None = None
+    chargerMaxAmps: float | None = None
+    chargerMinAmps: float | None = None
+    priority: int | None = None
+    enabled: bool | None = None
+    teslaHttpProxy: str | None = None
+    teslaClientId: str | None = None
 
 
 def _redact(v: VehicleConfig) -> dict:
@@ -62,6 +63,7 @@ def _redact(v: VehicleConfig) -> dict:
 
 @router.get("")
 def list_vehicles() -> JSONResponse:
+    """List all configured vehicles, with tokens redacted."""
     if _app_config is None:
         raise HTTPException(status_code=503, detail="Not initialised")
     return JSONResponse([_redact(v) for v in _app_config.vehicles], status_code=200)
@@ -69,6 +71,7 @@ def list_vehicles() -> JSONResponse:
 
 @router.post("")
 def add_vehicle(body: VehicleCreate) -> JSONResponse:
+    """Add a new managed vehicle."""
     if _app_config is None:
         raise HTTPException(status_code=503, detail="Not initialised")
     vehicle = VehicleConfig(**body.model_dump())
@@ -78,6 +81,7 @@ def add_vehicle(body: VehicleCreate) -> JSONResponse:
 
 @router.get("/{vehicle_id}")
 def get_vehicle(vehicle_id: str) -> JSONResponse:
+    """Return a single vehicle by id, with tokens redacted."""
     if _app_config is None:
         raise HTTPException(status_code=503, detail="Not initialised")
     vehicle = _app_config.get_vehicle(vehicle_id)
@@ -88,9 +92,10 @@ def get_vehicle(vehicle_id: str) -> JSONResponse:
 
 @router.patch("/{vehicle_id}")
 def patch_vehicle(vehicle_id: str, body: VehicleUpdate) -> JSONResponse:
+    """Apply a partial update to a vehicle's configuration."""
     if _app_config is None:
         raise HTTPException(status_code=503, detail="Not initialised")
-    updates: Dict[str, Any] = {
+    updates: dict[str, Any] = {
         k: v for k, v in body.model_dump().items() if v is not None
     }
     if not updates:
@@ -103,6 +108,7 @@ def patch_vehicle(vehicle_id: str, body: VehicleUpdate) -> JSONResponse:
 
 @router.delete("/{vehicle_id}")
 def delete_vehicle(vehicle_id: str) -> JSONResponse:
+    """Remove a vehicle from the configuration."""
     if _app_config is None:
         raise HTTPException(status_code=503, detail="Not initialised")
     removed = _app_config.remove_vehicle(vehicle_id)
@@ -115,13 +121,16 @@ def delete_vehicle(vehicle_id: str) -> JSONResponse:
 def list_tesla_vehicles(vehicle_id: str) -> JSONResponse:
     """
     Fetch the list of Tesla vehicles linked to the given vehicle's OAuth token.
+
     Useful for onboarding: select a vehicle from the account.
     """
     if _app_config is None:
         raise HTTPException(status_code=503, detail="Not initialised")
     vehicle = _app_config.get_vehicle(vehicle_id)
     if vehicle is None:
-        raise HTTPException(status_code=404, detail=f"Vehicle config {vehicle_id} not found")
+        raise HTTPException(
+            status_code=404, detail=f"Vehicle config {vehicle_id} not found"
+        )
     try:
         api = TeslaAPI(vehicle)
         tesla_vehicles = api.get_vehicles()

--- a/tesla_smart_charger/tesla_api.py
+++ b/tesla_smart_charger/tesla_api.py
@@ -34,9 +34,11 @@ class TeslaAPI:
     ----------
     vehicle:
         The vehicle configuration containing credentials and proxy settings.
+
     """
 
     def __init__(self, vehicle: VehicleConfig) -> None:
+        """Build a client bound to a single vehicle's config and credentials."""
         self.vehicle = vehicle
 
     # ─── Internal helpers ──────────────────────────────────────────────────────
@@ -47,14 +49,17 @@ class TeslaAPI:
 
     @property
     def _fleet_api_url(self) -> str:
-        """The Fleet API base URL for this vehicle's region.
+        """
+        The Fleet API base URL for this vehicle's region.
 
         Uses the proxy URL directly if it's already a Fleet API URL
         (set by users who don't run the tesla-http-proxy), otherwise
         derives it from the region.
         """
         proxy = self._proxy
-        if any(proxy.startswith(url) for url in constants.TESLA_FLEET_API_URLS.values()):
+        if any(
+            proxy.startswith(url) for url in constants.TESLA_FLEET_API_URLS.values()
+        ):
             return proxy
         return constants.TESLA_FLEET_API_URLS.get(
             self.vehicle.region, constants.TESLA_AUDIENCE
@@ -64,11 +69,16 @@ class TeslaAPI:
         return {"Authorization": f"Bearer {self.vehicle.teslaAccessToken}"}
 
     def _tls(self) -> dict:
-        """mTLS certs — only sent when the proxy is NOT a direct Fleet API URL.
+        """
+        MTLS certs — only sent when the proxy is NOT a direct Fleet API URL.
+
         Server certificate verification is disabled because the proxy's self-
-        signed cert CN won't match the Docker service name (tesla-http-proxy)."""
+        signed cert CN won't match the Docker service name (tesla-http-proxy).
+        """
         proxy = self._proxy
-        if any(proxy.startswith(url) for url in constants.TESLA_FLEET_API_URLS.values()):
+        if any(
+            proxy.startswith(url) for url in constants.TESLA_FLEET_API_URLS.values()
+        ):
             return {}
         return {
             "verify": False,
@@ -92,7 +102,8 @@ class TeslaAPI:
         stop_max_attempt_number=5,
     )
     def get_vehicles(self) -> list:
-        """Return the list of Tesla vehicles linked to this OAuth token.
+        """
+        Return the list of Tesla vehicles linked to this OAuth token.
 
         Uses the Fleet API directly (Bearer token only, no mTLS), even
         when a tesla-http-proxy is configured — listing vehicles does
@@ -123,9 +134,10 @@ class TeslaAPI:
         vehicle_id = self.vehicle.teslaVehicleId
         if not vehicle_id:
             raise HTTPException(
-                status_code=400, detail="teslaVehicleId is not set on this vehicle config"
+                status_code=400,
+                detail="teslaVehicleId is not set on this vehicle config",
             )
-        tsc_logger.info(f"Requesting data for vehicle {vehicle_id}.")
+        tsc_logger.info("Requesting data for vehicle %s.", vehicle_id)
         try:
             r = requests.get(
                 f"{self._proxy}{constants.TESLA_API_VEHICLE_DATA_URL.format(id=vehicle_id)}",
@@ -151,7 +163,9 @@ class TeslaAPI:
         # Use the VIN (17 chars) for command URLs — the tesla-http-proxy rejects
         # numeric Fleet API IDs in command paths.
         vehicle_id = self.vehicle.vin or self.vehicle.teslaVehicleId
-        tsc_logger.info(f"Setting charge limit → {amp_limit}A for vehicle {vehicle_id}.")
+        tsc_logger.info(
+            "Setting charge limit → %sA for vehicle %s.", amp_limit, vehicle_id
+        )
         try:
             r = requests.post(
                 f"{self._proxy}{constants.TESLA_API_CHARGE_AMP_LIMIT_URL.format(id=vehicle_id)}",
@@ -200,7 +214,8 @@ class TeslaAPI:
             self.vehicle = self.vehicle.model_copy(
                 update={"teslaAccessToken": access, "teslaRefreshToken": refresh}
             )
-            return access, refresh
-        except requests.RequestException as exc:
-            tsc_logger.error(f"Token refresh failed for vehicle {self.vehicle.id}: {exc}")
+        except requests.RequestException:
+            tsc_logger.exception("Token refresh failed for vehicle %s", self.vehicle.id)
             return None
+        else:
+            return access, refresh

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from tesla_smart_charger import constants
 from tesla_smart_charger.app_config import AppConfig
 from tesla_smart_charger.routes import (
     auth_routes,
@@ -20,7 +21,6 @@ from tesla_smart_charger.routes import (
     vehicle_routes,
 )
 
-
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
 
@@ -28,7 +28,7 @@ def _make_app(tmp_path: Path) -> tuple[FastAPI, AppConfig]:
     """Build a minimal FastAPI app wired to a fresh AppConfig in tmp_path."""
     app_cfg = AppConfig(str(tmp_path / "config"))
     # Prevent migration from picking up the project-root config.json
-    app_cfg._legacy_file = tmp_path / "no_legacy.json"  # noqa: SLF001
+    app_cfg._legacy_file = tmp_path / "no_legacy.json"
     app_cfg.load()
 
     app = FastAPI()
@@ -55,6 +55,7 @@ def _make_app(tmp_path: Path) -> tuple[FastAPI, AppConfig]:
 
 
 def test_status_returns_200(tmp_path: Path) -> None:
+    """GET /api/v1/status returns 200 with the expected top-level fields."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app, raise_server_exceptions=True)
 
@@ -68,6 +69,7 @@ def test_status_returns_200(tmp_path: Path) -> None:
 
 
 def test_status_configured_false_by_default(tmp_path: Path) -> None:
+    """A freshly created AppConfig reports configured=False."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -76,12 +78,15 @@ def test_status_configured_false_by_default(tmp_path: Path) -> None:
 
 
 def test_status_monitor_and_overload_flags(tmp_path: Path) -> None:
+    """Status reflects the injected monitor_active_fn/overload_active_fn callbacks."""
     app_cfg = AppConfig(str(tmp_path / "config"))
-    app_cfg._legacy_file = tmp_path / "no_legacy.json"  # noqa: SLF001
+    app_cfg._legacy_file = tmp_path / "no_legacy.json"
     app_cfg.load()
 
     app = FastAPI()
-    status_routes.init(app_cfg, monitor_active_fn=lambda: True, overload_active_fn=lambda: True)
+    status_routes.init(
+        app_cfg, monitor_active_fn=lambda: True, overload_active_fn=lambda: True
+    )
     app.include_router(status_routes.router)
 
     client = TestClient(app)
@@ -94,6 +99,7 @@ def test_status_monitor_and_overload_flags(tmp_path: Path) -> None:
 
 
 def test_get_config_returns_200(tmp_path: Path) -> None:
+    """GET /api/v1/config returns 200 and never leaks the password hash."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -108,6 +114,7 @@ def test_get_config_returns_200(tmp_path: Path) -> None:
 
 
 def test_post_config_updates_field(tmp_path: Path) -> None:
+    """POST /api/v1/config updates and persists a single field."""
     app, app_cfg = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -119,6 +126,7 @@ def test_post_config_updates_field(tmp_path: Path) -> None:
 
 
 def test_post_config_empty_body_returns_400(tmp_path: Path) -> None:
+    """POST /api/v1/config with no fields to update returns 400."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -155,6 +163,7 @@ VEHICLE_PAYLOAD = {
 
 
 def test_list_vehicles_empty(tmp_path: Path) -> None:
+    """GET /api/v1/vehicles returns an empty list for a fresh config."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -164,6 +173,7 @@ def test_list_vehicles_empty(tmp_path: Path) -> None:
 
 
 def test_add_vehicle_returns_201(tmp_path: Path) -> None:
+    """POST /api/v1/vehicles creates a vehicle and redacts its tokens."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -178,6 +188,7 @@ def test_add_vehicle_returns_201(tmp_path: Path) -> None:
 
 
 def test_get_vehicle_by_id(tmp_path: Path) -> None:
+    """GET /api/v1/vehicles/{id} returns the matching vehicle."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -188,6 +199,7 @@ def test_get_vehicle_by_id(tmp_path: Path) -> None:
 
 
 def test_get_vehicle_not_found_returns_404(tmp_path: Path) -> None:
+    """GET /api/v1/vehicles/{id} returns 404 for an unknown id."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -196,6 +208,7 @@ def test_get_vehicle_not_found_returns_404(tmp_path: Path) -> None:
 
 
 def test_patch_vehicle(tmp_path: Path) -> None:
+    """PATCH /api/v1/vehicles/{id} updates the given field."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -206,6 +219,7 @@ def test_patch_vehicle(tmp_path: Path) -> None:
 
 
 def test_patch_vehicle_empty_body_returns_400(tmp_path: Path) -> None:
+    """PATCH /api/v1/vehicles/{id} with no fields to update returns 400."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -215,6 +229,7 @@ def test_patch_vehicle_empty_body_returns_400(tmp_path: Path) -> None:
 
 
 def test_delete_vehicle(tmp_path: Path) -> None:
+    """DELETE /api/v1/vehicles/{id} removes the vehicle."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -227,6 +242,7 @@ def test_delete_vehicle(tmp_path: Path) -> None:
 
 
 def test_delete_vehicle_not_found_returns_404(tmp_path: Path) -> None:
+    """DELETE /api/v1/vehicles/{id} returns 404 for an unknown id."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -242,7 +258,7 @@ def test_vehicles_persist_across_reload(tmp_path: Path) -> None:
     client.post("/api/v1/vehicles", json=VEHICLE_PAYLOAD)
 
     app2_cfg = AppConfig(str(tmp_path / "config"))
-    app2_cfg._legacy_file = tmp_path / "no_legacy.json"  # noqa: SLF001
+    app2_cfg._legacy_file = tmp_path / "no_legacy.json"
     app2_cfg.load()
     assert len(app2_cfg.vehicles) == 1
     assert app2_cfg.vehicles[0].name == "Model Y"
@@ -252,6 +268,7 @@ def test_vehicles_persist_across_reload(tmp_path: Path) -> None:
 
 
 def test_auth_setup_enable(tmp_path: Path) -> None:
+    """POST /api/v1/auth/setup enables auth and stores a password hash."""
     app, app_cfg = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -266,6 +283,7 @@ def test_auth_setup_enable(tmp_path: Path) -> None:
 
 
 def test_auth_setup_enable_missing_password_returns_400(tmp_path: Path) -> None:
+    """Enabling auth without a password returns 400."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -274,15 +292,19 @@ def test_auth_setup_enable_missing_password_returns_400(tmp_path: Path) -> None:
 
 
 def test_auth_verify_no_auth_always_valid(tmp_path: Path) -> None:
+    """POST /api/v1/auth/verify is always valid when auth is disabled."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
-    r = client.post("/api/v1/auth/verify", json={"username": "anyone", "password": "whatever"})
+    r = client.post(
+        "/api/v1/auth/verify", json={"username": "anyone", "password": "whatever"}
+    )
     assert r.status_code == 200
     assert r.json()["valid"] is True
 
 
 def test_auth_verify_correct_credentials(tmp_path: Path) -> None:
+    """POST /api/v1/auth/verify accepts the correct username/password."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -298,6 +320,7 @@ def test_auth_verify_correct_credentials(tmp_path: Path) -> None:
 
 
 def test_auth_verify_wrong_password_returns_401(tmp_path: Path) -> None:
+    """POST /api/v1/auth/verify rejects an incorrect password."""
     app, _ = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -312,6 +335,7 @@ def test_auth_verify_wrong_password_returns_401(tmp_path: Path) -> None:
 
 
 def test_auth_disable(tmp_path: Path) -> None:
+    """POST /api/v1/auth/setup can disable auth after enabling it."""
     app, app_cfg = _make_app(tmp_path)
     client = TestClient(app)
 
@@ -329,8 +353,6 @@ def test_auth_disable(tmp_path: Path) -> None:
 
 def test_history_returns_200_with_in_memory_db(tmp_path: Path) -> None:
     """History endpoint should succeed even with an in-memory/new SQLite DB."""
-    from tesla_smart_charger import constants
-
     db_path = str(tmp_path / "test.db")
     original_db_type = constants.DB_TYPE
     original_db_path = constants.DB_FILE_PATH

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -9,22 +9,21 @@ import pytest
 from tesla_smart_charger.app_config import AppConfig
 from tesla_smart_charger.models import OverloadStrategy, TeslaRegion, VehicleConfig
 
-
 # ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 
 @pytest.fixture
 def tmp_config_dir(tmp_path: Path) -> Path:
-    """A temporary directory to use as the config directory."""
+    """Return a temporary directory to use as the config directory."""
     return tmp_path / "config"
 
 
 @pytest.fixture
 def cfg(tmp_config_dir: Path) -> AppConfig:
-    """A freshly loaded AppConfig backed by a temporary directory (no migration)."""
+    """Return a freshly loaded AppConfig backed by a temp directory (no migration)."""
     app = AppConfig(str(tmp_config_dir))
     # Point legacy file to a path that never exists so migration is never triggered
-    app._legacy_file = tmp_config_dir / "no_legacy_config.json"  # noqa: SLF001
+    app._legacy_file = tmp_config_dir / "no_legacy_config.json"
     app.load()
     return app
 
@@ -35,7 +34,7 @@ def cfg(tmp_config_dir: Path) -> AppConfig:
 def test_load_creates_defaults_when_no_files(tmp_config_dir: Path) -> None:
     """First load with no existing files should produce sensible defaults."""
     app = AppConfig(str(tmp_config_dir))
-    app._legacy_file = tmp_config_dir / "no_legacy.json"  # noqa: SLF001
+    app._legacy_file = tmp_config_dir / "no_legacy.json"
     app.load()
 
     assert app.system.homeMaxAmps == 30.0
@@ -147,7 +146,7 @@ def test_migration_from_legacy_config(tmp_path: Path) -> None:
     config_dir = tmp_path / "config"
     # Patch _legacy_file to point to tmp_path/config.json
     app = AppConfig(str(config_dir))
-    app._legacy_file = legacy  # noqa: SLF001
+    app._legacy_file = legacy
 
     app.load()
 
@@ -173,11 +172,13 @@ def test_migration_skipped_when_system_json_exists(tmp_path: Path) -> None:
     config_dir = tmp_path / "config"
     config_dir.mkdir()
     # Write a valid system.json — migration should be skipped
-    (config_dir / "system.json").write_text(json.dumps({"homeMaxAmps": 10.0, "configured": True}))
+    (config_dir / "system.json").write_text(
+        json.dumps({"homeMaxAmps": 10.0, "configured": True})
+    )
     (config_dir / "vehicles.json").write_text("[]")
 
     app = AppConfig(str(config_dir))
-    app._legacy_file = legacy  # noqa: SLF001
+    app._legacy_file = legacy
     app.load()
 
     # system.json's value wins (migration was skipped)
@@ -212,6 +213,7 @@ def test_add_vehicle(cfg: AppConfig) -> None:
 
 
 def test_get_vehicle_found(cfg: AppConfig) -> None:
+    """get_vehicle returns the matching vehicle by id."""
     v = cfg.add_vehicle(VehicleConfig(name="Model S"))
     found = cfg.get_vehicle(v.id)
     assert found is not None
@@ -219,10 +221,12 @@ def test_get_vehicle_found(cfg: AppConfig) -> None:
 
 
 def test_get_vehicle_not_found(cfg: AppConfig) -> None:
+    """get_vehicle returns None for an unknown id."""
     assert cfg.get_vehicle("nonexistent-id") is None
 
 
 def test_update_vehicle(cfg: AppConfig) -> None:
+    """update_vehicle applies and persists a partial update."""
     v = cfg.add_vehicle(VehicleConfig(name="Roadster", chargerMaxAmps=16.0))
     updated = cfg.update_vehicle(v.id, {"chargerMaxAmps": 32.0, "name": "Roadster 2"})
 
@@ -234,22 +238,28 @@ def test_update_vehicle(cfg: AppConfig) -> None:
 
 
 def test_update_vehicle_returns_none_for_unknown_id(cfg: AppConfig) -> None:
+    """update_vehicle returns None for an unknown id."""
     result = cfg.update_vehicle("no-such-id", {"name": "Ghost"})
     assert result is None
 
 
 def test_remove_vehicle(cfg: AppConfig) -> None:
+    """remove_vehicle deletes the vehicle and returns True."""
     v = cfg.add_vehicle(VehicleConfig(name="Cybertruck"))
     assert cfg.remove_vehicle(v.id) is True
     assert cfg.vehicles == []
 
 
 def test_remove_vehicle_returns_false_for_unknown_id(cfg: AppConfig) -> None:
+    """remove_vehicle returns False for an unknown id."""
     assert cfg.remove_vehicle("ghost-id") is False
 
 
 def test_update_vehicle_tokens(cfg: AppConfig) -> None:
-    v = cfg.add_vehicle(VehicleConfig(teslaAccessToken="old_at", teslaRefreshToken="old_rt"))
+    """update_vehicle_tokens atomically updates the access/refresh tokens."""
+    v = cfg.add_vehicle(
+        VehicleConfig(teslaAccessToken="old_at", teslaRefreshToken="old_rt")
+    )
     cfg.update_vehicle_tokens(v.id, "new_at", "new_rt")
     updated = cfg.get_vehicle(v.id)
     assert updated is not None
@@ -258,19 +268,22 @@ def test_update_vehicle_tokens(cfg: AppConfig) -> None:
 
 
 def test_multiple_vehicles(cfg: AppConfig) -> None:
+    """Multiple vehicles can be added and are all retained."""
     cfg.add_vehicle(VehicleConfig(name="Car A", priority=1))
     cfg.add_vehicle(VehicleConfig(name="Car B", priority=2))
     cfg.add_vehicle(VehicleConfig(name="Car C", priority=3))
 
     assert len(cfg.vehicles) == 3
     names = [v.name for v in cfg.vehicles]
-    assert "Car A" in names and "Car C" in names
+    assert "Car A" in names
+    assert "Car C" in names
 
 
 # ─── update_system ────────────────────────────────────────────────────────────
 
 
 def test_update_system_merges_fields(cfg: AppConfig) -> None:
+    """update_system merges given fields while leaving others unchanged."""
     original_voltage = cfg.system.voltage
     cfg.update_system({"homeMaxAmps": 99.0})
 
@@ -279,7 +292,10 @@ def test_update_system_merges_fields(cfg: AppConfig) -> None:
 
 
 def test_update_system_nested_auth(cfg: AppConfig) -> None:
-    cfg.update_system({"auth": {"enabled": True, "username": "admin", "passwordHash": "hash123"}})
+    """update_system merges nested auth fields rather than replacing the dict."""
+    cfg.update_system(
+        {"auth": {"enabled": True, "username": "admin", "passwordHash": "hash123"}}
+    )
 
     assert cfg.system.auth.enabled is True
     assert cfg.system.auth.username == "admin"
@@ -287,6 +303,7 @@ def test_update_system_nested_auth(cfg: AppConfig) -> None:
 
 
 def test_mark_configured(cfg: AppConfig) -> None:
+    """mark_configured sets configured=True and persists it."""
     assert cfg.system.configured is False
     cfg.mark_configured()
     assert cfg.system.configured is True

--- a/tests/test_charger_config.py
+++ b/tests/test_charger_config.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from tesla_smart_charger.charger_config import ChargerConfig
 
 
-@pytest.fixture()
+@pytest.fixture
 def config_file(tmp_path: str) -> str:
     """Create a temporary config file."""
     config = {
@@ -109,7 +109,6 @@ def test_set_config(config_file: str) -> None:
     tesla_config.load_config()
 
     class Config(BaseModel):
-
         """Config class for Tesla Smart Charger."""
 
         homeMaxAmps: float
@@ -190,13 +189,13 @@ def test_validate_config() -> None:
             "teslaClientId": "12234567890",
         },
     )
-    with pytest.raises(ValueError): # noqa: PT011
+    with pytest.raises(ValueError, match="homeMaxAmps"):
         tesla_config.validate_config({"chargerMaxAmps": 11.0, "chargerMinAmps": 6.0})
-    with pytest.raises(ValueError): # noqa: PT011
+    with pytest.raises(ValueError, match="homeMaxAmps"):
         tesla_config.validate_config(
             {"chargerMaxAmps": 11.0, "chargerMinAmps": 6.0, "downStepPercentage": 0.5},
         )
-    with pytest.raises(ValueError): # noqa: PT011
+    with pytest.raises(ValueError, match="homeMaxAmps"):
         tesla_config.validate_config(
             {
                 "chargerMaxAmps": 11.0,

--- a/tests/test_overload_handler.py
+++ b/tests/test_overload_handler.py
@@ -4,12 +4,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tesla_smart_charger.app_config import AppConfig
 from tesla_smart_charger.handlers import overload_handler
 from tesla_smart_charger.models import SystemConfig
-from tesla_smart_charger.app_config import AppConfig
-
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
+
 
 def _make_app_config(voltage: float = 230.0, home_max_amps: float = 32.0) -> AppConfig:
     """Return a minimal AppConfig with the given system settings."""
@@ -21,8 +21,16 @@ def _make_app_config(voltage: float = 230.0, home_max_amps: float = 32.0) -> App
 
 # ─── _calculate_new_charge_limit ──────────────────────────────────────────────
 
+
 @pytest.mark.parametrize(
-    "current_charge_limit, current_em_consumption, max_charge_limit, min_charge_limit, house_max_power, expected",
+    (
+        "current_charge_limit",
+        "current_em_consumption",
+        "max_charge_limit",
+        "min_charge_limit",
+        "house_max_power",
+        "expected",
+    ),
     [
         (16, 16, 16, 6, 16, 16),
         (15, 17, 16, 6, 16, 14),
@@ -32,7 +40,7 @@ def _make_app_config(voltage: float = 230.0, home_max_amps: float = 32.0) -> App
         (25, 35, 25, 6, 32, 22),
     ],
 )
-def test_calculate_new_charge_limit(
+def test_calculate_new_charge_limit(  # noqa: PLR0913, PLR0917
     current_charge_limit: float,
     current_em_consumption: float,
     max_charge_limit: float,
@@ -41,7 +49,7 @@ def test_calculate_new_charge_limit(
     expected: int,
 ) -> None:
     """Core algorithm: reduce by excess, clamp to [min, max]."""
-    result = overload_handler._calculate_new_charge_limit(  # noqa: SLF001
+    result = overload_handler._calculate_new_charge_limit(
         current_charge_limit,
         current_em_consumption,
         max_charge_limit,
@@ -53,13 +61,14 @@ def test_calculate_new_charge_limit(
 
 # ─── _get_consumption ─────────────────────────────────────────────────────────
 
+
 def test_get_consumption_returns_amps() -> None:
     """230 W / 230 V = 1.0 A."""
     app_config = _make_app_config(voltage=230.0)
     mock_em = MagicMock()
     mock_em.get_consumption.return_value = 230.0
 
-    result = overload_handler._get_consumption(mock_em, app_config)  # noqa: SLF001
+    result = overload_handler._get_consumption(mock_em, app_config)
     assert result == pytest.approx(1.0)
 
 
@@ -69,11 +78,12 @@ def test_get_consumption_returns_zero_on_error() -> None:
     mock_em = MagicMock()
     mock_em.get_consumption.side_effect = ValueError("EM offline")
 
-    result = overload_handler._get_consumption(mock_em, app_config)  # noqa: SLF001
+    result = overload_handler._get_consumption(mock_em, app_config)
     assert result == 0.0
 
 
 # ─── _save_event ──────────────────────────────────────────────────────────────
+
 
 def test_save_event_calls_insert_data() -> None:
     """_save_event should call insert_data on the DB controller."""
@@ -85,7 +95,7 @@ def test_save_event_calls_insert_data() -> None:
 
         with patch("time.strftime") as mock_strftime:
             mock_strftime.return_value = "2024-01-01 12:01:30"
-            overload_handler._save_event("2024-01-01 12:00:00", "vehicle-uuid-123")  # noqa: SLF001
+            overload_handler._save_event("2024-01-01 12:00:00", "vehicle-uuid-123")
 
         mock_ctrl.insert_data.assert_called_once()
         call_kwargs = mock_ctrl.insert_data.call_args[0][0]
@@ -97,14 +107,14 @@ def test_save_event_calls_insert_data() -> None:
 
 # ─── Session state ────────────────────────────────────────────────────────────
 
+
 def test_session_flag_toggle() -> None:
     """is_session_active reflects _set_session calls."""
-    overload_handler._set_session(False)  # noqa: SLF001
+    overload_handler._set_session(active=False)
     assert overload_handler.is_session_active() is False
 
-    overload_handler._set_session(True)  # noqa: SLF001
+    overload_handler._set_session(active=True)
     assert overload_handler.is_session_active() is True
 
-    overload_handler._set_session(False)  # noqa: SLF001
+    overload_handler._set_session(active=False)
     assert overload_handler.is_session_active() is False
-

--- a/uv.lock
+++ b/uv.lock
@@ -32,9 +32,9 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
-    { name = "idna", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "exceptiongroup" },
+    { name = "idna" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
@@ -49,9 +49,9 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
-    { name = "idna", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
@@ -191,14 +191,14 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "mypy-extensions", marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pathspec", marker = "python_full_version < '3.10'" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pytokens", marker = "python_full_version < '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" } },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pytokens" },
+    { name = "tomli" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8c/ad/33adf4708633d047950ff2dfdea2e215d84ac50ef95aff14a614e4b6e9b2/black-25.11.0.tar.gz", hash = "sha256:9a323ac32f5dc75ce7470501b887250be5005a01602e931a15e45593f70f6e08", size = 655669, upload-time = "2025-11-10T01:53:50.558Z" }
 wheels = [
@@ -237,14 +237,14 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "mypy-extensions", marker = "python_full_version >= '3.10'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pathspec", marker = "python_full_version >= '3.10'" },
-    { name = "platformdirs", version = "4.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pytokens", marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
+    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "mypy-extensions" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "platformdirs", version = "4.10.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pytokens" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/37/5628dd55bf2b34257fc7603f0fe97c40e3aaf24265f416a9c85c95ca1436/black-26.5.1.tar.gz", hash = "sha256:dd321f668053961824bcc1be1cc1df748b2d7e4fa28086b08331e577b0100a73", size = 679439, upload-time = "2026-05-18T16:53:36.107Z" }
 wheels = [
@@ -447,7 +447,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
@@ -462,7 +462,7 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/98/518d8e5081007684232226f475082b30087d0f585e8457db087298259f49/click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96", size = 353007, upload-time = "2026-05-22T04:08:37.769Z" }
 wheels = [
@@ -594,7 +594,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version < '3.10'" },
+    { name = "tomli" },
 ]
 
 [[package]]
@@ -715,7 +715,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version >= '3.10' and python_full_version <= '3.11'" },
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -741,7 +741,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -756,11 +756,11 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "annotated-doc", marker = "python_full_version < '3.10'" },
-    { name = "pydantic", marker = "python_full_version < '3.10'" },
-    { name = "starlette", version = "0.49.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-    { name = "typing-inspection", marker = "python_full_version < '3.10'" },
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette", version = "0.49.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/72/0df5c58c954742f31a7054e2dd1143bae0b408b7f36b59b85f928f9b456c/fastapi-0.128.8.tar.gz", hash = "sha256:3171f9f328c4a218f0a8d2ba8310ac3a55d1ee12c28c949650288aee25966007", size = 375523, upload-time = "2026-02-11T15:19:36.69Z" }
 wheels = [
@@ -775,11 +775,11 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "annotated-doc", marker = "python_full_version >= '3.10'" },
-    { name = "pydantic", marker = "python_full_version >= '3.10'" },
-    { name = "starlette", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10'" },
-    { name = "typing-inspection", marker = "python_full_version >= '3.10'" },
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette", version = "1.2.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
 wheels = [
@@ -839,8 +839,8 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.10'" },
-    { name = "h11", marker = "python_full_version < '3.10'" },
+    { name = "certifi" },
+    { name = "h11" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/18/e51f5729684acaaab4d1cfca0777ac0f86440c65d2814992442ed5ef02e1/httpcore2-2.0.0.tar.gz", hash = "sha256:403692e0a0e8ea6de90993cdea815b2454d2ff5426e61d2a244846c12506af76", size = 63864, upload-time = "2026-05-12T17:59:22.073Z" }
 wheels = [
@@ -855,8 +855,8 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "h11", marker = "python_full_version >= '3.10'" },
-    { name = "truststore", marker = "python_full_version >= '3.10'" },
+    { name = "h11" },
+    { name = "truststore" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e6/34/18f1c596e677962f040284246f393b10a1f8ce440b3a7e69c637d0f1c7ad/httpcore2-2.3.0.tar.gz", hash = "sha256:07327e251560960eea8e969d92d4c6a325feb13cca39e25340731336c3baf924", size = 64300, upload-time = "2026-06-01T13:15:02.998Z" }
 wheels = [
@@ -928,10 +928,10 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "certifi", marker = "python_full_version < '3.10'" },
-    { name = "httpcore2", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "idna", marker = "python_full_version < '3.10'" },
+    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "certifi" },
+    { name = "httpcore2", version = "2.0.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "idna" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/70/95/868b3df4aa6f9cecb42aaf82a55a5a2c8ef40df76d709b812e1553d6a928/httpx2-2.0.0.tar.gz", hash = "sha256:f354249d2a9edce26e08fd2ad2276e98317b5763f673bb0d90f3ce9382cc2aed", size = 79506, upload-time = "2026-05-12T17:59:23.174Z" }
 wheels = [
@@ -946,10 +946,10 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "httpcore2", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "idna", marker = "python_full_version >= '3.10'" },
-    { name = "truststore", marker = "python_full_version >= '3.10'" },
+    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "httpcore2", version = "2.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "idna" },
+    { name = "truststore" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9f/9a/cca0b9145f13d8ae34b885ae28d403a1469a433abc78e0f94f4ce94e650b/httpx2-2.3.0.tar.gz", hash = "sha256:227e7c41d95a76d4077a52640564132777215fc3394e07b66a3116c33d668fa9", size = 81115, upload-time = "2026-06-01T13:15:04.324Z" }
 wheels = [
@@ -970,7 +970,7 @@ name = "importlib-metadata"
 version = "8.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.10'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
 wheels = [
@@ -1034,7 +1034,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "importlib-metadata", marker = "python_full_version < '3.10'" },
+    { name = "importlib-metadata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8d/37/02347f6d6d8279247a5837082ebc26fc0d5aaeaf75aa013fcbb433c777ab/markdown-3.9.tar.gz", hash = "sha256:d2900fe1782bd33bdbbd56859defef70c2e78fc46668f8eb9df3128138f2cb6a", size = 364585, upload-time = "2025-09-04T20:25:22.885Z" }
 wheels = [
@@ -1498,8 +1498,8 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.10'" },
+    { name = "packaging" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/fd/437901c891f58a7b9096511750247535e891d2d5a5a6eefbc9386a2b41d5/pyproject_api-1.9.1.tar.gz", hash = "sha256:43c9918f49daab37e302038fc1aed54a8c7a91a9fa935d00b9a485f37e0f5335", size = 22710, upload-time = "2025-05-12T14:41:58.025Z" }
 wheels = [
@@ -1514,8 +1514,8 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "packaging" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/62/62/0fe346fe380b1aafaf819c8cb195d3241bb4f355f908e6339814131a830b/pyproject_api-1.10.1.tar.gz", hash = "sha256:c2b2726bd7aa9217b6c50b621fef5b2ae5def4d55b779c9e0694c15e0a8517ba", size = 23477, upload-time = "2026-05-28T14:22:14.049Z" }
 wheels = [
@@ -1530,13 +1530,13 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
-    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "pluggy", marker = "python_full_version < '3.10'" },
-    { name = "pygments", marker = "python_full_version < '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.10'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
@@ -1551,13 +1551,13 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
-    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "pluggy", marker = "python_full_version >= '3.10'" },
-    { name = "pygments", marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
@@ -1768,10 +1768,10 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version < '3.10'" },
-    { name = "charset-normalizer", marker = "python_full_version < '3.10'" },
-    { name = "idna", marker = "python_full_version < '3.10'" },
-    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3", version = "2.6.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
@@ -1786,10 +1786,10 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.10'" },
-    { name = "charset-normalizer", marker = "python_full_version >= '3.10'" },
-    { name = "idna", marker = "python_full_version >= '3.10'" },
-    { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3", version = "2.7.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
@@ -1807,27 +1807,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.16"
+version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
-    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
-    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
-    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
-    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
-    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
-    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
-    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
-    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
+    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
+    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
 ]
 
 [[package]]
@@ -1865,8 +1865,8 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/de/1a/608df0b10b53b0beb96a37854ee05864d182ddd4b1156a22f1ad3860425a/starlette-0.49.3.tar.gz", hash = "sha256:1c14546f299b5901a1ea0e34410575bc33bbd741377a10484a54445588d00284", size = 2655031, upload-time = "2025-11-01T15:12:26.13Z" }
 wheels = [
@@ -1881,8 +1881,8 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.10' and python_full_version < '3.13'" },
+    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
@@ -1938,7 +1938,7 @@ dev = [
     { name = "httpx2", specifier = ">=0.28.1" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=5.0.0" },
-    { name = "ruff", specifier = ">=0.15.10" },
+    { name = "ruff", specifier = "==0.16.0" },
     { name = "tox", specifier = ">=4.23.2" },
 ]
 docs = [
@@ -2018,17 +2018,17 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "cachetools", version = "6.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "chardet", marker = "python_full_version < '3.10'" },
-    { name = "colorama", marker = "python_full_version < '3.10'" },
-    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "packaging", marker = "python_full_version < '3.10'" },
-    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pluggy", marker = "python_full_version < '3.10'" },
-    { name = "pyproject-api", version = "1.9.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "tomli", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
-    { name = "virtualenv", marker = "python_full_version < '3.10'" },
+    { name = "cachetools", version = "6.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "chardet" },
+    { name = "colorama" },
+    { name = "filelock", version = "3.19.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "platformdirs", version = "4.4.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pluggy" },
+    { name = "pyproject-api", version = "1.9.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "tomli" },
+    { name = "typing-extensions" },
+    { name = "virtualenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/b2/cee55172e5e10ce030b087cd3ac06641e47d08a3dc8d76c17b157dba7558/tox-4.30.3.tar.gz", hash = "sha256:f3dd0735f1cd4e8fbea5a3661b77f517456b5f0031a6256432533900e34b90bf", size = 202799, upload-time = "2025-10-02T16:24:39.974Z" }
 wheels = [
@@ -2043,18 +2043,18 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "cachetools", version = "7.1.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "colorama", marker = "python_full_version >= '3.10'" },
-    { name = "filelock", version = "3.29.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "packaging", marker = "python_full_version >= '3.10'" },
-    { name = "platformdirs", version = "4.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pluggy", marker = "python_full_version >= '3.10'" },
-    { name = "pyproject-api", version = "1.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "python-discovery", marker = "python_full_version >= '3.10'" },
-    { name = "tomli", marker = "python_full_version == '3.10.*'" },
-    { name = "tomli-w", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
-    { name = "virtualenv", marker = "python_full_version >= '3.10'" },
+    { name = "cachetools", version = "7.1.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "colorama" },
+    { name = "filelock", version = "3.29.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "platformdirs", version = "4.10.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pluggy" },
+    { name = "pyproject-api", version = "1.10.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-discovery" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tomli-w" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "virtualenv" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/5b/4f09156a3f7bf3c4fa23212717f097c59126d81e2c557e6fd872a62db38a/tox-4.55.1.tar.gz", hash = "sha256:0678fbf26dd5b559b1ef128fa4388325920219322ebc8cc5f3497627c00f4472", size = 280676, upload-time = "2026-06-03T20:01:03.487Z" }
 wheels = [
@@ -2123,9 +2123,9 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "h11", marker = "python_full_version < '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.10'" },
+    { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" } },
+    { name = "h11" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/4f/f9fdac7cf6dd79790eb165639b5c452ceeabc7bbabbba4569155470a287d/uvicorn-0.39.0.tar.gz", hash = "sha256:610512b19baa93423d2892d7823741f6d27717b642c8964000d7194dded19302", size = 82001, upload-time = "2025-12-21T13:05:17.973Z" }
 wheels = [
@@ -2134,13 +2134,13 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
-    { name = "httptools", marker = "python_full_version < '3.10'" },
-    { name = "python-dotenv", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "pyyaml", marker = "python_full_version < '3.10'" },
-    { name = "uvloop", marker = "python_full_version < '3.10' and platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
-    { name = "watchfiles", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
-    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv", version = "1.2.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles", version = "1.1.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "websockets", version = "15.0.1", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [[package]]
@@ -2151,9 +2151,9 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "h11", marker = "python_full_version >= '3.10'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
+    { name = "click", version = "8.4.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "h11" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
@@ -2162,13 +2162,13 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
-    { name = "httptools", marker = "python_full_version >= '3.10'" },
-    { name = "python-dotenv", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.10'" },
-    { name = "uvloop", marker = "python_full_version >= '3.10' and platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
-    { name = "watchfiles", version = "1.2.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
-    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv", version = "1.2.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles", version = "1.2.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "websockets", version = "16.0", source = { registry = "https://pypi.org/simple" } },
 ]
 
 [[package]]
@@ -2284,7 +2284,7 @@ resolution-markers = [
     "python_full_version < '3.10'",
 ]
 dependencies = [
-    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "anyio", version = "4.12.1", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
 wheels = [
@@ -2406,7 +2406,7 @@ resolution-markers = [
     "python_full_version >= '3.10'",
 ]
 dependencies = [
-    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
 wheels = [


### PR DESCRIPTION
/api/v1/status now serves cached/placeholder vehicle telemetry instantly and refreshes in the background instead of blocking on the Tesla API, so the dashboard renders immediately with per-card loading state.

Also fixes ruff's config (was under [lint.*] instead of [tool.ruff.*], so the intended "ALL" ruleset was never active), cleans up the lint backlog that surfaced, and pins ruff==0.16.0 in both the dev deps and tox's lint env so local/CI linting stay in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vehicle telemetry now refreshes in the background, keeping the dashboard responsive.
  * Added per-vehicle loading states with spinners and “Fetching…” placeholders while telemetry is pending.
  * Refined overload handling for multi-vehicle adjustment sessions.

* **Bug Fixes**
  * Improved robustness and recovery with better stack-trace logging across background jobs, database, and monitoring.
  * API endpoints now return clearer error responses on invalid requests and failures.

* **Documentation / Tests / Chores**
  * Updated endpoint typing, docstrings, and added coverage for invalid config fields and auth/history behaviors.
  * Linting setup was tightened and standardized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->