### PR TITLE
fix: disable charge buttons during Starting state

### DIFF
--- a/dashboard/src/pages/Dashboard/VehicleCard.tsx
+++ b/dashboard/src/pages/Dashboard/VehicleCard.tsx
@@ -67,10 +67,11 @@ export function VehicleCard({
   const showWake = !v.pending && v.online === false && Boolean(v.teslaVehicleId)
 
   // Show start/stop charge buttons when vehicle is online and we have command access
-  // Tesla charging_state values: Charging, Supercharging, Complete, Stopped, Disconnected, NoPower
+  // Tesla charging_state values: Charging, Supercharging, Starting, Complete, Stopped, Disconnected, NoPower
   const isCharging = ['Charging', 'Supercharging'].includes(v.chargingState ?? '')
     || (v.chargerActualCurrent != null && v.chargerActualCurrent > 0)
-  const showChargeControls = canCommand && v.online === true && !v.pending
+  const isStarting = v.chargingState === 'Starting'
+  const showChargeControls = canCommand && v.online === true && !v.pending && !isStarting
 
   return (
     <Card>


### PR DESCRIPTION
Prevents showing start/stop buttons while Tesla reports 'Starting' transitional state after a charge command is sent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Charging controls are now hidden while a vehicle is starting to charge, preventing unavailable actions during this transition.
  * Existing charging detection and control behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->